### PR TITLE
Note/Alert on Free Form Collection File Arrangement

### DIFF
--- a/app/views/items/_tree.html.haml
+++ b/app/views/items/_tree.html.haml
@@ -1,8 +1,14 @@
 %strong 
   Note on file organization and description: 
-The files and folders names below were not changed after the University Archives received them from the department and include numerous abbreviations. Folders and files display in alphabetical order, and files often have generic, nondescriptive titles. Please contact an archivist at 
-= mail_to "illiarch@illinois.edu"
-for assistance navigating these files.
+
+.alert.alert-info
+  The files and folders names below were not changed after the University Archives 
+  received them from the department and include numerous abbreviations. 
+  Folders and files display in alphabetical order, and files often have generic, 
+  nondescriptive titles. Please contact an archivist at 
+  = succeed "." do
+    %a{href: "mailto:#{@collection.medusa_repository.email}"}= @collection.medusa_repository.email
+    for assistance navigating these files
 
 #dl-free-form-split-pane
   #dl-free-form-tree-view{"data-toggle":    "popover",

--- a/app/views/items/_tree.html.haml
+++ b/app/views/items/_tree.html.haml
@@ -1,3 +1,9 @@
+%strong 
+  Note on file organization and description: 
+The files and folders names below were not changed after the University Archives received them from the department and include numerous abbreviations. Folders and files display in alphabetical order, and files often have generic, nondescriptive titles. Please contact an archivist at 
+= mail_to "illiarch@illinois.edu"
+for assistance navigating these files.
+
 #dl-free-form-split-pane
   #dl-free-form-tree-view{"data-toggle":    "popover",
                           title:            "Collection Folder Tree",


### PR DESCRIPTION
This PR is for issue [#64](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=35598449), adding a note for the user to help make navigating the free-form collections feel less ambiguous. 

### Summary of Changes:
- The `_tree.html.haml` file was updated with the note as well as the ability to email an archivist
- The `alert.alert-info `component used in the `_description.html.haml` file was also used for this, to give a uniform look to the messaging. 

### Screenshots below verify that only free-form collections should have this note/alert visible. 

A collection that is **NOT** free-form:

<img width="1384" alt="Screenshot 2024-03-28 at 12 43 15 PM" src="https://github.com/medusa-project/kumquat/assets/103534307/e90b43a4-61d2-4d55-810c-47ce57cc8c18">

A collection that **IS** free-form:

<img width="1157" alt="Screenshot 2024-03-28 at 1 20 19 PM" src="https://github.com/medusa-project/kumquat/assets/103534307/4fcb1ebd-f55e-46b0-82fe-deb769bd9063">
