### PR TITLE
feature/DLD-66 -- View dropdown menu on collection pages is confusing

### DIFF
--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -24,6 +24,11 @@
         %span.caret
       .dropdown-menu.dropdown-menu-right
         - if @uofi_user
+          = link_to collection_tree_path(@collection), 
+                    target: '_blank',
+                    class: 'dropdown-item' do 
+            %i.far.fa-folder-open
+              Browse Collection 
           = link_to @permitted_params.merge(format: :json),
                     target: '_blank',
                     class: 'dropdown-item' do

--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -24,11 +24,12 @@
         %span.caret
       .dropdown-menu.dropdown-menu-right
         - if @uofi_user
-          = link_to collection_tree_path(@collection), 
+          = link_to collection_tree_path(@collection),
                     target: '_blank',
-                    class: 'dropdown-item' do 
-            %i.far.fa-folder-open
-              Browse Collection 
+                    class: 'dropdown-item' do
+            %i.fa.fa-folder-open 
+            Browse Collection
+            .dropdown-divider{role: "separator"}
           = link_to @permitted_params.merge(format: :json),
                     target: '_blank',
                     class: 'dropdown-item' do
@@ -39,7 +40,7 @@
                     class: 'dropdown-item' do
             %i.fa.fa-code
              IIIF Representation
-          .dropdown-divider{role: "separator"}
+          .dropdown-divider{role: "separator"} 
         = link_to admin_collection_path(@collection),
                   target: '_blank',
                   class: 'dropdown-item' do


### PR DESCRIPTION
This PR is for [issue #66](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=35601899) - modifying the View dropdown menu in the collection pages to more prominently show an option to browse the collection so users don't feel confused by the availability of options like JSON or IIIF Representation. 

Summary of Changes:

- Adds an option inside `views/collections/show.html.haml` that includes a link to browse the current collection
- The 'Browse collection' menu option is separated at the top of the menu, similar to how `Admin View` is at the bottom of the menu
- An open folder icon is included
- The path opens the collection's `collection_tree_path` in a new tab

<img width="1381" alt="Screenshot 2024-04-16 at 11 27 40 AM" src="https://github.com/medusa-project/kumquat/assets/103534307/1a4ce5ca-200f-46fe-9e37-020468ba0bc1">

