### PR TITLE
feature/DLD-67 View dropdown menu on item page confusing

### DIFF
--- a/app/views/items/_show_button_group.html.haml
+++ b/app/views/items/_show_button_group.html.haml
@@ -12,6 +12,13 @@
       View
       %span.caret
     .dropdown-menu.dropdown-menu-right
+      - if item.collection.physical_collection_url.present?
+        = link_to item.collection.physical_collection_url,
+                  target: '_blank',
+                  class: 'dropdown-item' do 
+          = icon_for(item.collection)
+            Physical Collection
+          .dropdown-divider{role: "separator"}
       = link_to @permitted_params.merge(format: :atom),
                 target: '_blank',
                 class: 'dropdown-item' do
@@ -47,12 +54,6 @@
                   class: 'dropdown-item' do
           %i.fa.fa-book
           Library Catalog Record
-      - if item.collection.physical_collection_url.present?
-        = link_to item.collection.physical_collection_url,
-                  target: '_blank',
-                  class: 'dropdown-item' do
-          = icon_for(item.collection)
-            Physical Collection
       - if current_user&.medusa_user?
         .dropdown-divider
         = link_to admin_collection_item_path(item.collection, item),


### PR DESCRIPTION
Addresses Issue [#67](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=35602366) and relates to Issue [#66 ](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=35601899)

- Very similarly to issue 66, moves the `Physical Collection` option inside item show page to the top of the `View` menu
- Adds a divider to make it easier to navigate for user

Note: I'm unable to view the item show page(s) locally, so I can't verify how this change actually appears on my machine, but I used the implementation for issue 66 as a guide.