### PR TITLE
Feature/dld 55 - Citation Generation 

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -57,6 +57,7 @@ const DLItemView = function() {
                 var source = container.find('[name=dl-citation-source]').val();
                 var title = container.find('[name=dl-citation-title]').val();
                 var url = container.find('[name=dl-citation-url]').val();
+                var collection = container.find('[name=dl-citation-collection]').val();
                 var citation = '';
 
                 switch ($(this).val()) {
@@ -73,8 +74,9 @@ const DLItemView = function() {
                                 dateObj.getMonthName() + ' ' + dateObj.getDay() + '). ';
                         }
                         title = '<i>' + title + '</i>. ';
+                        collection = 'In ' + collection + ', ';
                         url = 'Retrieved from ' + url;
-                        citation = author + date + title + url;
+                        citation = author + date + title + collection + url;
                         break;
                     case 'Chicago':
                         // https://owl.english.purdue.edu/owl/resource/717/05/
@@ -82,23 +84,25 @@ const DLItemView = function() {
                             author += ', ';
                         }
                         title = '"' + title + '," ';
+                        collection = 'In ' + collection + ', ';
                         source = '<i>' + source + '</i>, ';
                         date = 'last modified ' + dateObj.getMonthName() +
                             ' ' + dateObj.getDay() + ', ' +
                             dateObj.getFullYear() + ', ';
                         url += '.';
-                        citation = author + title + source + date + url;
+                        citation = author + title + collection + source + date + url;
                         break;
                     case 'MLA':
                         // "A Page on a Web Site"
                         // https://owl.english.purdue.edu/owl/resource/747/08/
                         title = '"' + title + '." ';
+                        collection = 'In ' + collection + ', ';
                         source = '<i>' + source + ',</i> ';
                         date = dateObj.getDay() + ' ' +
                             dateObj.getAbbreviatedMonthName() + ' ' +
                             dateObj.getFullYear() + ', ';
                         url = url.replace('http://', '').replace('https://', '') + '.';
-                        citation = title + source + date + url;
+                        citation = title + collection + source + date + url;
                         break;
                 }
                 container.find('.dl-citation').html(citation);

--- a/app/views/items/_cite_panel.html.haml
+++ b/app/views/items/_cite_panel.html.haml
@@ -13,6 +13,7 @@
         %hr/
         %div{"data-item-id": "#{item.repository_id}"}
           = hidden_field_tag('dl-citation-author', item.element(:creator)&.value)
+          = hidden_field_tag('dl-citation-collection', item.collection.title)
           = hidden_field_tag('dl-citation-date-created', item.created_at.iso8601)
           = hidden_field_tag('dl-citation-source',
                              Setting::string(Setting::Keys::ORGANIZATION_NAME))


### PR DESCRIPTION
Addresses issue [#55](https://github.com/orgs/medusa-project/projects/2?pane=issue&itemId=33117746) - including the collection name in the generated citations since this is critical for understanding the context of the item.

Summary of Changes:

- inside `_cite_panel.html.haml` includes a `field tag` for an `item's collection title`
- inside `assets/javascripts/items.js` declares `var collection`, which finds the field tag above; string interpolation of the collection variable is included in the formatting of the `MLA, Chicago, and APA` style citation formats. 

### Chicago

<img width="562" alt="Screenshot 2024-04-25 at 3 02 43 PM" src="https://github.com/medusa-project/kumquat/assets/103534307/3fd61076-6989-4bc3-9a35-618088730cf9">

### MLA

<img width="558" alt="Screenshot 2024-04-25 at 3 03 00 PM" src="https://github.com/medusa-project/kumquat/assets/103534307/8afd151d-6b38-428c-a497-0a20103a993a">

### APA 

<img width="568" alt="Screenshot 2024-04-25 at 3 02 52 PM" src="https://github.com/medusa-project/kumquat/assets/103534307/c2ef9010-90f7-4260-8a83-216ff66a8178">
