### PR TITLE
Feature/dld 95 - Cite should be at the same level as share and contact

### DIFF
--- a/app/helpers/items_helper.rb
+++ b/app/helpers/items_helper.rb
@@ -751,14 +751,6 @@ module ItemsHelper
         <i class="fa fa-share-alt"></i> Share <span class="caret"></span>
       </button>
       <div class="dropdown-menu">'
-    # cite
-    if entity.kind_of?(Item)
-      html << link_to('#', onclick: 'return false;', class: 'dropdown-item',
-                      data: { toggle: 'modal', target: '#dl-cite-modal' }) do
-        raw('<i class="fas fa-pen-square"></i> Cite')
-      end
-      html << '<div class="dropdown-divider"></div>'
-    end
     # email
     html << link_to("mailto:?subject=#{title}&body=#{url}", class: 'dropdown-item') do
       raw('<i class="fa fa-envelope"></i> Email')

--- a/app/views/items/_show_button_group.html.haml
+++ b/app/views/items/_show_button_group.html.haml
@@ -3,7 +3,7 @@
 
 #item-show-buttons.btn-group.float-right{role: "group"}
   = link_to '#dl-cite-modal', class: 'btn btn-light', "data-toggle": "modal" do 
-    %i.fa.fa-university
+    %i.fa.fa-quote-left
     Cite 
   = share_button(item)
   .btn-group{role: "group"}

--- a/app/views/items/_show_button_group.html.haml
+++ b/app/views/items/_show_button_group.html.haml
@@ -2,6 +2,9 @@
 -# item [Item]
 
 #item-show-buttons.btn-group.float-right{role: "group"}
+  = link_to '#dl-cite-modal', class: 'btn btn-light', "data-toggle": "modal" do 
+    %i.fa.fa-quote-left
+    Cite 
   = share_button(item)
   .btn-group{role: "group"}
     %button.btn.btn-light.dropdown-toggle{"aria-expanded": "false",

--- a/app/views/items/_show_button_group.html.haml
+++ b/app/views/items/_show_button_group.html.haml
@@ -3,7 +3,7 @@
 
 #item-show-buttons.btn-group.float-right{role: "group"}
   = link_to '#dl-cite-modal', class: 'btn btn-light', "data-toggle": "modal" do 
-    %i.fa.fa-quote-left
+    %i.fa.fa-university
     Cite 
   = share_button(item)
   .btn-group{role: "group"}


### PR DESCRIPTION
Addresses issue [95](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=62012923) (related to issue [55](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=33117746)) 

Summary of Changes:

1. Inside `items_helper.rb`, remove `Cite` option from the dropdown `Share menu` on an `item-show page`
2. Inside shared partial `_show_button_group,` link to the `Cite modal` as its own option within `#item-show-buttons.btn-group...` 
3. Display a `university icon` before the `Cite` option

<img width="467" alt="Screenshot 2024-05-08 at 11 44 55 AM" src="https://github.com/medusa-project/kumquat/assets/103534307/b7c23d8b-2a80-44f0-9756-0461898d05dc">









