### PR TITLE
feature/DLD-95 Rearrange item show buttons in alpha order

### DIFF
--- a/app/views/items/_show_button_group.html.haml
+++ b/app/views/items/_show_button_group.html.haml
@@ -5,6 +5,20 @@
   = link_to '#dl-cite-modal', class: 'btn btn-light', "data-toggle": "modal" do 
     %i.fa.fa-quote-left
     Cite 
+  - mailto = curator_mailto(item)
+  - if mailto
+    .btn-group
+      %button.btn.btn-light.dropdown-toggle{"aria-expanded": "false",
+                                            "aria-haspopup": "true",
+                                            "data-toggle": "dropdown",
+                                            type: "button"}
+        %i.fa.fa-envelope
+        Contact
+        %span.caret
+      .dropdown-menu.dropdown-menu-right{role: "menu"}
+        = link_to mailto, class: 'dropdown-item' do
+          %i.fa.fa-envelope
+          Email Curator
   = share_button(item)
   .btn-group{role: "group"}
     %button.btn.btn-light.dropdown-toggle{"aria-expanded": "false",
@@ -64,17 +78,4 @@
                   class: 'dropdown-item' do
           %i.fa.fa-lock
           Admin View
-  - mailto = curator_mailto(item)
-  - if mailto
-    .btn-group
-      %button.btn.btn-light.dropdown-toggle{"aria-expanded": "false",
-                                            "aria-haspopup": "true",
-                                            "data-toggle": "dropdown",
-                                            type: "button"}
-        %i.fa.fa-envelope
-        Contact
-        %span.caret
-      .dropdown-menu.dropdown-menu-right{role: "menu"}
-        = link_to mailto, class: 'dropdown-item' do
-          %i.fa.fa-envelope
-          Email Curator
+


### PR DESCRIPTION
This is an update for previously closed [issue 95](https://github.com/medusa-project/digital-library-issues/issues/95) 

Based on client feedback:

> We discussed this is the user council meeting yesterday, and we like how the button looks at the top level. However, we wanted to rearrange the order of the buttons to be in alphabetical order: [cite] [contact] [share] [view]

Updated order of buttons:

<img width="1430" alt="Screenshot 2024-05-15 at 9 49 31 AM" src="https://github.com/medusa-project/kumquat/assets/103534307/ab5c3848-1f48-426f-afb5-fe72329bea18">
