### PR TITLE
Update/DLD 55 - citation formatting

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -111,7 +111,7 @@ GEM
       minitest (>= 5.1)
       mutex_m
       tzinfo (~> 2.0)
-    airbrussh (1.4.0)
+    airbrussh (1.5.2)
       sshkit (>= 1.6.1, != 1.7.0)
     ast (2.4.2)
     autoprefixer-rails (9.6.1.1)
@@ -138,7 +138,7 @@ GEM
     base64 (0.2.0)
     bigdecimal (3.1.7)
     builder (3.2.4)
-    capistrano (3.14.1)
+    capistrano (3.18.1)
       airbrussh (>= 1.0.0)
       i18n
       rake (>= 10.0.0)
@@ -189,7 +189,7 @@ GEM
       tilt
     hashie (5.0.0)
     httpclient (2.8.3)
-    i18n (1.14.4)
+    i18n (1.14.5)
       concurrent-ruby (~> 1.0)
     io-console (0.7.2)
     irb (1.12.0)
@@ -237,11 +237,13 @@ GEM
       net-protocol
     net-protocol (0.2.2)
       timeout
-    net-scp (3.0.0)
-      net-ssh (>= 2.6.5, < 7.0.0)
+    net-scp (4.0.0)
+      net-ssh (>= 2.6.5, < 8.0.0)
+    net-sftp (4.0.0)
+      net-ssh (>= 5.0.0, < 8.0.0)
     net-smtp (0.5.0)
       net-protocol
-    net-ssh (6.1.0)
+    net-ssh (7.2.3)
     netaddr (2.0.4)
     nio4r (2.7.1)
     nokogiri (1.16.3)
@@ -321,7 +323,7 @@ GEM
       thor (~> 1.0, >= 1.2.2)
       zeitwerk (~> 2.6)
     rainbow (3.1.1)
-    rake (13.1.0)
+    rake (13.2.1)
     rdoc (6.6.3.1)
       psych (>= 4.0.0)
     regexp_parser (2.7.0)
@@ -356,8 +358,11 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
-    sshkit (1.21.1)
+    sshkit (1.22.2)
+      base64
+      mutex_m
       net-scp (>= 1.1.2)
+      net-sftp (>= 2.1.2)
       net-ssh (>= 2.8.0)
     standard (1.24.3)
       language_server-protocol (~> 3.17.0.2)

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -49,10 +49,9 @@ const DLItemView = function() {
                         // "Nonperiodical Web Document or Report":
                         // https://owl.english.purdue.edu/owl/resource/560/10/
                         // date should be date of item NOT date of creation?
-                        if (!author) {
-                            citation = title + date + collection + repo + source + url;
-                        } else {
-                          author += '. ';
+                        if (author) {
+                            author += '. ';
+                        }
                         
                           if (date) {
                             var formattedDate = '';
@@ -72,17 +71,21 @@ const DLItemView = function() {
                               formattedDate = 'n.d.';
                             }
                             
-                            date = formattedDate + '. ';
-                        } else { 
+                          } else { 
                             date = 'n.d. ';
-                        }
-                        title = '<i>' + title + '</i>. ';
-                        collection = 'In ' + collection + ', ';
-                        url = 'Retrieved from ' + url;
-                        repo = ' ' + repo + ', ';
-                        source = '<i>' + source + '</i>, ';
-                        citation = author + date + title + collection + repo + source + url;
-                        }
+                          }
+                          date = '(' + formattedDate + '). ';
+                          title = '<i>' + title + '</i>. ';
+                          collection = 'In ' + collection + ', ';
+                          url = 'Retrieved from ' + url;
+                          repo = ' ' + repo + ', ';
+                          source = '<i>' + source + '</i>, ';
+                          citation = author + date + title + collection + repo + source + url;
+
+                          if (!author) {
+                              citation = author + title + date + collection + repo + source + url;
+                          }
+                        
                         break;
                     case 'Chicago':
                         // https://owl.english.purdue.edu/owl/resource/717/05/
@@ -124,36 +127,36 @@ const DLItemView = function() {
                         if (author) {
                             author += '. ';
                         }
-                        if (date) {
-                          var formattedDate = '';
-                          var month = dateObj.getAbbreviatedMonthName();
-                          var day = dateObj.getDate();
-                          var year = dateObj.getFullYear();
-                          
-                          if (month && day && year) {
-                            formattedDate = month + ' ' + day + ', ' + year;
-                          } else if (month && year) {
-                            formattedDate = month + ' ' + year;
-                          } else if (day && year) {
-                            formattedDate = day + ', ' + year;
-                          } else if (year) {
-                            formattedDate = year.toString();
+                          if (date) {
+                            var formattedDate = '';
+                            var month = dateObj.getAbbreviatedMonthName();
+                            var day = dateObj.getDate();
+                            var year = dateObj.getFullYear();
+                            
+                            if (month && day && year) {
+                              formattedDate = month + ' ' + day + ', ' + year;
+                            } else if (month && year) {
+                              formattedDate = month + ' ' + year;
+                            } else if (day && year) {
+                              formattedDate = day + ', ' + year;
+                            } else if (year) {
+                              formattedDate = year.toString();
+                            } else {
+                              formattedDate = 'Date Unknown. ';
+                            }
+                            
                           } else {
-                            formattedDate = 'Date Unknown. ';
+                            date = 'Date Unknown. ';
                           }
                           
-                        } else {
-                          date = 'Date Unknown. ';
-                        }
-                        
-                        date = formattedDate + '. ';
-                        title = '"' + title + '." ';
-                        collection = 'In ' + collection + '. ';
-                        source = '<i>' + source + '.</i> ';
-                        repo = ' ' + repo + '. ';
-                        url = url.replace('http://', '').replace('https://', '') + '.';
-                        citation = title + date + collection + repo + source + url;
-                        break;
+                          date = formattedDate + '. ';
+                          collection = 'In ' + collection + '. ';
+                          source = '<i>' + source + '.</i> ';
+                          repo = ' ' + repo + '. ';
+                          url = url.replace('http://', '').replace('https://', '') + '.';
+                          title = ' ' + title + '. ';
+                          citation = author + title + date + collection + repo + source + url;
+                          break;
                 }
                 container.find('.dl-citation').html(citation);
             }).trigger('change');

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -76,10 +76,10 @@ const DLItemView = function() {
                           }
                           date = '(' + formattedDate + '). ';
                           title = '<i>' + title + '</i>. ';
-                          collection = 'In ' + collection + ', ';
-                          url = 'Retrieved from ' + url;
+                          collection = collection + ', ';
+                          url = url;
                           repo = ' ' + repo + ', ';
-                          source = '<i>' + source + '</i>, ';
+                          source = source + '. ';
                           citation = author + date + title + collection + repo + source + url;
 
                           if (!author) {

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -71,9 +71,7 @@ const DLItemView = function() {
                         // date should be date of item NOT date of creation?
                         if (author) {
                             author += '. ';
-                        } else {
-                            author = '[Unknown]. ';
-                        }
+                        } 
                         if (date) {
                             date = '(' + dateObj.getFullYear() + ', ' +
                                 dateObj.getMonthName() + ' ' + dateObj.getDay() + '). ';
@@ -111,12 +109,12 @@ const DLItemView = function() {
                         // https://owl.english.purdue.edu/owl/resource/747/08/
                         // CreatorName, TitleOfItem, DateOfItem, NameOfCollection, NAmeOfRepo, NAmeOfInst, URL
                         title = '"' + title + '." ';
-                        collection = 'In ' + collection + ', ';
-                        source = '<i>' + source + ',</i> ';
-                        repo = ' ' + repo + ', ';
+                        collection = 'In ' + collection + '. ';
+                        source = '<i>' + source + '.</i> ';
+                        repo = ' ' + repo + '. ';
                         date = dateObj.getDay() + ' ' +
                             dateObj.getAbbreviatedMonthName() + ' ' +
-                            dateObj.getFullYear() + ', ';
+                            dateObj.getFullYear() + '. ';
                         url = url.replace('http://', '').replace('https://', '') + '.';
                         citation = title + date + collection + repo + source + url;
                         break;

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -16,43 +16,26 @@ const DLItemView = function() {
 
         const init = function() {
             Date.prototype.getAbbreviatedMonthName = function() {
-                switch (this.getMonth()) {
-                    case 1: return 'Jan.';
-                    case 2: return 'Feb.';
-                    case 3: return 'Mar.';
-                    case 4: return 'Apr.';
-                    case 5: return 'May';
-                    case 6: return 'June';
-                    case 7: return 'July';
-                    case 8: return 'Aug.';
-                    case 9: return 'Sept.';
-                    case 10: return 'Oct.';
-                    case 11: return 'Nov.';
-                    case 12: return 'Dec.';
-                }
+                const monthNames = [
+                    'Jan.', 'Feb.', 'Mar.', 'Apr.', 'May,', 'June',
+                    'July', 'Aug.', 'Sept.', 'Oct.', 'Nov.', 'Dec.'
+                ];
+                return monthNames[this.getMonth()];
             };
             Date.prototype.getMonthName = function() {
-                switch (this.getMonth()) {
-                    case 1: return 'January';
-                    case 2: return 'February';
-                    case 3: return 'March';
-                    case 4: return 'April';
-                    case 5: return 'May';
-                    case 6: return 'June';
-                    case 7: return 'July';
-                    case 8: return 'August';
-                    case 9: return 'September';
-                    case 10: return 'October';
-                    case 11: return 'November';
-                    case 12: return 'December';
-                }
+                const monthNames = [
+                  'January', 'February', 'March', 'April', 'May', 'June',
+                  'July', 'August', 'September', 'October', 'November',
+                  'December'
+                ];
+                return monthNames[this.getMonth()];
             };
             $('[name=dl-citation-format]').on('change', function() {
                 var container = $(this).parent();
                 var item_id = container.data('item-id');
 
                 var author = container.find('[name=dl-citation-author]').val();
-                var date = container.find('[name=dl-citation-date-created]').val();
+                var date = container.find('[name=dl-citation-date]').val();
                 var dateObj = new Date(date);
                 var source = container.find('[name=dl-citation-source]').val();
                 var title = container.find('[name=dl-citation-title]').val();
@@ -72,9 +55,24 @@ const DLItemView = function() {
                           author += '. ';
                         
                           if (date) {
-                            date = '(' + dateObj.getFullYear() + ', ' +
-                                dateObj.getMonthName() + ' ' + dateObj.getDay() + '). ';
+                            var formattedDate = '';
+                            var month = dateObj.getAbbreviatedMonthName();
+                            var day = dateObj.getDate();
+                            var year = dateObj.getFullYear();
 
+                            if (month && day && year) {
+                                formattedDate = month + ' ' + day + ', ' + year;
+                            } else if (month && year) {
+                                formattedDate = month + ' ' + year;
+                            } else if (day && year) {
+                                formattedDate = day + ', ' + year;
+                            } else if (year) {
+                              formattedDate = year.toString();
+                            } else {
+                              formattedDate = 'n.d.';
+                            }
+                            
+                            date = formattedDate + '. ';
                         } else { 
                             date = 'n.d. ';
                         }
@@ -91,15 +89,33 @@ const DLItemView = function() {
                         if (author) {
                             author += ', ';
                         }
-                        title = '"' + title + '," ';
-                        collection = 'In ' + collection + ', ';
-                        source = '<i>' + source + '</i>, ';
-                        repo = ' ' + repo + ', ';
-                        date = dateObj.getMonthName() +
-                            ' ' + dateObj.getDay() + ', ' +
-                            dateObj.getFullYear() + ', ';
-                        url += '.';
+                          if (date) {
+                            var formattedDate = '';
+                            var month = dateObj.getAbbreviatedMonthName();
+                            var day = dateObj.getDate();
+                            var year = dateObj.getFullYear();
+                            
+                            if (month && day && year) {
+                              formattedDate = month + ' ' + day + ', ' + year;
+                            } else if (month && year) {
+                              formattedDate = month + ' ' + year;
+                            } else if (day && year) {
+                              formattedDate = day + ', ' + year;
+                            } else if (year) {
+                              formattedDate = year.toString();
+                            } else {
+                              formattedDate = ' ';
+                            }
+                          
+                          date = formattedDate + '. ';
+                          url += '.';
+                          title = '"' + title + '," ';
+                          collection = 'In ' + collection + ', ';
+                          source = '<i>' + source + '</i>, ';
+                          repo = ' ' + repo + ', ';
+                          
                         citation = author + title + date + collection + repo + source + url;
+                        }
                         break;
                     case 'MLA':
                         // "A Page on a Web Site"
@@ -108,18 +124,33 @@ const DLItemView = function() {
                         if (author) {
                             author += '. ';
                         }
+                        if (date) {
+                          var formattedDate = '';
+                          var month = dateObj.getAbbreviatedMonthName();
+                          var day = dateObj.getDate();
+                          var year = dateObj.getFullYear();
+                          
+                          if (month && day && year) {
+                            formattedDate = month + ' ' + day + ', ' + year;
+                          } else if (month && year) {
+                            formattedDate = month + ' ' + year;
+                          } else if (day && year) {
+                            formattedDate = day + ', ' + year;
+                          } else if (year) {
+                            formattedDate = year.toString();
+                          } else {
+                            formattedDate = 'Date Unknown. ';
+                          }
+                          
+                        } else {
+                          date = 'Date Unknown. ';
+                        }
+                        
+                        date = formattedDate + '. ';
                         title = '"' + title + '." ';
                         collection = 'In ' + collection + '. ';
                         source = '<i>' + source + '.</i> ';
                         repo = ' ' + repo + '. ';
-                        if (date) {
-
-                          date = dateObj.getDay() + ' ' +
-                          dateObj.getAbbreviatedMonthName() + ' ' +
-                          dateObj.getFullYear() + '. ';
-                        } else {
-                          date = 'Date Unknown. ';
-                        }
                         url = url.replace('http://', '').replace('https://', '') + '.';
                         citation = title + date + collection + repo + source + url;
                         break;

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -150,9 +150,9 @@ const DLItemView = function() {
                           }
                           
                           date = formattedDate + '. ';
-                          collection = 'In ' + collection + '. ';
-                          source = '<i>' + source + '.</i> ';
-                          repo = ' ' + repo + '. ';
+                          collection = collection + '. ';
+                          source = source + '. ';
+                          repo = ' ' + repo + ', ';
                           url = url.replace('http://', '').replace('https://', '') + '.';
                           title = ' ' + title + '. ';
                           citation = author + title + date + collection + repo + source + url;

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -113,8 +113,8 @@ const DLItemView = function() {
                           date = formattedDate + '. ';
                           url += '.';
                           title = '"' + title + '," ';
-                          collection = 'In ' + collection + ', ';
-                          source = '<i>' + source + '</i>, ';
+                          collection = collection + ', ';
+                          source = source + ', ';
                           repo = ' ' + repo + ', ';
                           
                         citation = author + title + date + collection + repo + source + url;

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -65,9 +65,6 @@ const DLItemView = function() {
                     case 'APA':
                         // "Nonperiodical Web Document or Report":
                         // https://owl.english.purdue.edu/owl/resource/560/10/
-                        // From Krista: CreatorName, (DateOfItem), TitleOfItem, NameOfCollection, NameOfRepo, NameOfInstitution, URL
-                        // if no author -> TitleOfItem, (DateOfItem), ... etc.
-                        // if no date -> "n.d."
                         // date should be date of item NOT date of creation?
                         if (!author) {
                             citation = title + date + collection + repo + source + url;
@@ -77,7 +74,7 @@ const DLItemView = function() {
                           if (date) {
                             date = '(' + dateObj.getFullYear() + ', ' +
                                 dateObj.getMonthName() + ' ' + dateObj.getDay() + '). ';
-                                
+
                         } else { 
                             date = 'n.d. ';
                         }
@@ -88,13 +85,9 @@ const DLItemView = function() {
                         source = '<i>' + source + '</i>, ';
                         citation = author + date + title + collection + repo + source + url;
                         }
-                        // citation_no_author = title + date + collection repo + source + url;
-                        // citation_no_date = author + "n.d" + title + collection + url;
                         break;
                     case 'Chicago':
                         // https://owl.english.purdue.edu/owl/resource/717/05/
-                        // skip components that don't exist
-                        // CreatorName, "TitleOfItem", DateOfItem, NameOfCollection, NameOfRepo, NameOfInst, URL
                         if (author) {
                             author += ', ';
                         }
@@ -112,13 +105,21 @@ const DLItemView = function() {
                         // "A Page on a Web Site"
                         // https://owl.english.purdue.edu/owl/resource/747/08/
                         // CreatorName, TitleOfItem, DateOfItem, NameOfCollection, NAmeOfRepo, NAmeOfInst, URL
+                        if (author) {
+                            author += '. ';
+                        }
                         title = '"' + title + '." ';
                         collection = 'In ' + collection + '. ';
                         source = '<i>' + source + '.</i> ';
                         repo = ' ' + repo + '. ';
-                        date = dateObj.getDay() + ' ' +
-                            dateObj.getAbbreviatedMonthName() + ' ' +
-                            dateObj.getFullYear() + '. ';
+                        if (date) {
+
+                          date = dateObj.getDay() + ' ' +
+                          dateObj.getAbbreviatedMonthName() + ' ' +
+                          dateObj.getFullYear() + '. ';
+                        } else {
+                          date = 'Date Unknown. ';
+                        }
                         url = url.replace('http://', '').replace('https://', '') + '.';
                         citation = title + date + collection + repo + source + url;
                         break;

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -69,12 +69,15 @@ const DLItemView = function() {
                         // if no author -> TitleOfItem, (DateOfItem), ... etc.
                         // if no date -> "n.d."
                         // date should be date of item NOT date of creation?
-                        if (author) {
-                            author += '. ';
-                        } 
-                        if (date) {
+                        if (!author) {
+                            citation = title + date + collection + repo + source + url;
+                        } else {
+                          author += '. ';
+                        
+                          if (date) {
                             date = '(' + dateObj.getFullYear() + ', ' +
                                 dateObj.getMonthName() + ' ' + dateObj.getDay() + '). ';
+                                
                         } else { 
                             date = 'n.d. ';
                         }
@@ -84,7 +87,8 @@ const DLItemView = function() {
                         repo = ' ' + repo + ', ';
                         source = '<i>' + source + '</i>, ';
                         citation = author + date + title + collection + repo + source + url;
-                        // citation_no_author = title + date + collection + url;
+                        }
+                        // citation_no_author = title + date + collection repo + source + url;
                         // citation_no_date = author + "n.d" + title + collection + url;
                         break;
                     case 'Chicago':

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -58,12 +58,17 @@ const DLItemView = function() {
                 var title = container.find('[name=dl-citation-title]').val();
                 var url = container.find('[name=dl-citation-url]').val();
                 var collection = container.find('[name=dl-citation-collection]').val();
+                var repo = container.find('[name=dl-citation-repository]').val();
                 var citation = '';
 
                 switch ($(this).val()) {
                     case 'APA':
                         // "Nonperiodical Web Document or Report":
                         // https://owl.english.purdue.edu/owl/resource/560/10/
+                        // From Krista: CreatorName, (DateOfItem), TitleOfItem, NameOfCollection, NameOfRepo, NameOfInstitution, URL
+                        // if no author -> TitleOfItem, (DateOfItem), ... etc.
+                        // if no date -> "n.d."
+                        // date should be date of item NOT date of creation?
                         if (author) {
                             author += '. ';
                         } else {
@@ -72,37 +77,48 @@ const DLItemView = function() {
                         if (date) {
                             date = '(' + dateObj.getFullYear() + ', ' +
                                 dateObj.getMonthName() + ' ' + dateObj.getDay() + '). ';
+                        } else { 
+                            date = 'n.d. ';
                         }
                         title = '<i>' + title + '</i>. ';
                         collection = 'In ' + collection + ', ';
                         url = 'Retrieved from ' + url;
-                        citation = author + date + title + collection + url;
+                        repo = ' ' + repo + ', ';
+                        source = '<i>' + source + '</i>, ';
+                        citation = author + date + title + collection + repo + source + url;
+                        // citation_no_author = title + date + collection + url;
+                        // citation_no_date = author + "n.d" + title + collection + url;
                         break;
                     case 'Chicago':
                         // https://owl.english.purdue.edu/owl/resource/717/05/
+                        // skip components that don't exist
+                        // CreatorName, "TitleOfItem", DateOfItem, NameOfCollection, NameOfRepo, NameOfInst, URL
                         if (author) {
                             author += ', ';
                         }
                         title = '"' + title + '," ';
                         collection = 'In ' + collection + ', ';
                         source = '<i>' + source + '</i>, ';
-                        date = 'last modified ' + dateObj.getMonthName() +
+                        repo = ' ' + repo + ', ';
+                        date = dateObj.getMonthName() +
                             ' ' + dateObj.getDay() + ', ' +
                             dateObj.getFullYear() + ', ';
                         url += '.';
-                        citation = author + title + collection + source + date + url;
+                        citation = author + title + date + collection + repo + source + url;
                         break;
                     case 'MLA':
                         // "A Page on a Web Site"
                         // https://owl.english.purdue.edu/owl/resource/747/08/
+                        // CreatorName, TitleOfItem, DateOfItem, NameOfCollection, NAmeOfRepo, NAmeOfInst, URL
                         title = '"' + title + '." ';
                         collection = 'In ' + collection + ', ';
                         source = '<i>' + source + ',</i> ';
+                        repo = ' ' + repo + ', ';
                         date = dateObj.getDay() + ' ' +
                             dateObj.getAbbreviatedMonthName() + ' ' +
                             dateObj.getFullYear() + ', ';
                         url = url.replace('http://', '').replace('https://', '') + '.';
-                        citation = title + collection + source + date + url;
+                        citation = title + date + collection + repo + source + url;
                         break;
                 }
                 container.find('.dl-citation').html(citation);

--- a/app/views/items/_cite_panel.html.haml
+++ b/app/views/items/_cite_panel.html.haml
@@ -15,6 +15,7 @@
           = hidden_field_tag('dl-citation-author', item.element(:creator)&.value)
           = hidden_field_tag('dl-citation-collection', item.collection.title)
           = hidden_field_tag('dl-citation-date-created', item.created_at.iso8601)
+          = hidden_field_tag('dl-citation-date', item.date.utc.iso8601)
           = hidden_field_tag('dl-citation-source',
                              Setting::string(Setting::Keys::ORGANIZATION_NAME))
           = hidden_field_tag('dl-citation-title', item.title)

--- a/app/views/items/_cite_panel.html.haml
+++ b/app/views/items/_cite_panel.html.haml
@@ -19,6 +19,7 @@
                              Setting::string(Setting::Keys::ORGANIZATION_NAME))
           = hidden_field_tag('dl-citation-title', item.title)
           = hidden_field_tag('dl-citation-url', item_url(item))
+          = hidden_field_tag('dl-citation-repository', item.collection.medusa_repository.title)
           %select.custom-select{name: "dl-citation-format"}
             %option APA
             %option Chicago

--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -1,5 +1,5 @@
 # config valid only for current version of Capistrano
-lock '3.14.1'
+lock '3.18.1'
 
 set :application, 'kumquat'
 set :repo_url, 'https://github.com/medusa-project/kumquat.git'


### PR DESCRIPTION
This is an update for [issue 55](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=33117746).

Summary of Changes:

- Includes the `collection's repository name`
- includes the `date of the original item`
- modifies how the Months are pulled from for generating an `item date`
- updates logic for `APA/MLA/Chicago to format based on official citation` guidelines provided by client
- updates `capistrano` gem for future deployments

Screenshots:

## MLA

<img width="543" alt="Screenshot 2024-05-22 at 10 13 05 AM" src="https://github.com/medusa-project/kumquat/assets/103534307/20be0cc6-177c-48f4-a7b8-27342a28cc0e">

## APA

<img width="538" alt="Screenshot 2024-05-22 at 10 11 57 AM" src="https://github.com/medusa-project/kumquat/assets/103534307/b638b876-f48d-44b6-93e1-661ddce36cf9">


## Chicago

<img width="545" alt="Screenshot 2024-05-22 at 10 12 33 AM" src="https://github.com/medusa-project/kumquat/assets/103534307/6f39fcdd-df79-4a42-883f-d861f0fa7d6e">
