### PR TITLE
Fixes to feature/DLD-55

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -103,18 +103,18 @@ const DLItemView = function() {
                         var year = dateObj.getFullYear();
                         
                         if (month && day && year) {
-                          formattedDate = month + ' ' + day + ', ' + year;
+                          formattedDate = month + ' ' + day + ', ' + year + '. ';
                         } else if (month && year) {
-                          formattedDate = month + ' ' + year;
+                          formattedDate = month + ' ' + year + '. ';
                         } else if (day && year) {
-                          formattedDate = day + ', ' + year;
+                          formattedDate = day + ', ' + year + '. ';
                         } else if (year) {
                           formattedDate = year.toString();
                         } else {
                           formattedDate = ' ';
                         }
                           
-                          date = formattedDate + '. ';
+                          date = formattedDate + ' ';
                           url += '.';
                           title = '"' + title + '," ';
                           collection = collection + ', ';

--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -36,6 +36,7 @@ const DLItemView = function() {
 
                 var author = container.find('[name=dl-citation-author]').val();
                 var date = container.find('[name=dl-citation-date]').val();
+                var date_created = container.find('[name=dl-citation-date-created]').val();
                 var dateObj = new Date(date);
                 var source = container.find('[name=dl-citation-source]').val();
                 var title = container.find('[name=dl-citation-title]').val();
@@ -52,28 +53,27 @@ const DLItemView = function() {
                         if (author) {
                             author += '. ';
                         }
-                        
-                          if (date) {
-                            var formattedDate = '';
-                            var month = dateObj.getAbbreviatedMonthName();
-                            var day = dateObj.getDate();
-                            var year = dateObj.getFullYear();
+                        if (!date) {
+                            date = date_created;
+                        }
+                          
+                        var formattedDate = '';
+                        var month = dateObj.getAbbreviatedMonthName();
+                        var day = dateObj.getDate();
+                        var year = dateObj.getFullYear();
 
-                            if (month && day && year) {
-                                formattedDate = month + ' ' + day + ', ' + year;
-                            } else if (month && year) {
-                                formattedDate = month + ' ' + year;
-                            } else if (day && year) {
-                                formattedDate = day + ', ' + year;
-                            } else if (year) {
-                              formattedDate = year.toString();
-                            } else {
-                              formattedDate = 'n.d.';
-                            }
-                            
-                          } else { 
-                            date = 'n.d. ';
-                          }
+                        if (month && day && year) {
+                            formattedDate = month + ' ' + day + ', ' + year;
+                        } else if (month && year) {
+                            formattedDate = month + ' ' + year;
+                        } else if (day && year) {
+                            formattedDate = day + ', ' + year;
+                        } else if (year) {
+                          formattedDate = year.toString();
+                        } else {
+                          formattedDate = 'n.d.';
+                        }
+  
                           date = '(' + formattedDate + '). ';
                           title = '<i>' + title + '</i>. ';
                           collection = collection + ', ';
@@ -92,23 +92,27 @@ const DLItemView = function() {
                         if (author) {
                             author += ', ';
                         }
-                          if (date) {
-                            var formattedDate = '';
-                            var month = dateObj.getAbbreviatedMonthName();
-                            var day = dateObj.getDate();
-                            var year = dateObj.getFullYear();
-                            
-                            if (month && day && year) {
-                              formattedDate = month + ' ' + day + ', ' + year;
-                            } else if (month && year) {
-                              formattedDate = month + ' ' + year;
-                            } else if (day && year) {
-                              formattedDate = day + ', ' + year;
-                            } else if (year) {
-                              formattedDate = year.toString();
-                            } else {
-                              formattedDate = ' ';
-                            }
+
+                        if (!date) {
+                          date = date_created;
+                        }
+                          
+                        var formattedDate = '';
+                        var month = dateObj.getAbbreviatedMonthName();
+                        var day = dateObj.getDate();
+                        var year = dateObj.getFullYear();
+                        
+                        if (month && day && year) {
+                          formattedDate = month + ' ' + day + ', ' + year;
+                        } else if (month && year) {
+                          formattedDate = month + ' ' + year;
+                        } else if (day && year) {
+                          formattedDate = day + ', ' + year;
+                        } else if (year) {
+                          formattedDate = year.toString();
+                        } else {
+                          formattedDate = ' ';
+                        }
                           
                           date = formattedDate + '. ';
                           url += '.';
@@ -118,7 +122,7 @@ const DLItemView = function() {
                           repo = ' ' + repo + ', ';
                           
                         citation = author + title + date + collection + repo + source + url;
-                        }
+                        
                         break;
                     case 'MLA':
                         // "A Page on a Web Site"
@@ -127,29 +131,29 @@ const DLItemView = function() {
                         if (author) {
                             author += '. ';
                         }
-                          if (date) {
-                            var formattedDate = '';
-                            var month = dateObj.getAbbreviatedMonthName();
-                            var day = dateObj.getDate();
-                            var year = dateObj.getFullYear();
-                            
-                            if (month && day && year) {
-                              formattedDate = month + ' ' + day + ', ' + year;
-                            } else if (month && year) {
-                              formattedDate = month + ' ' + year;
-                            } else if (day && year) {
-                              formattedDate = day + ', ' + year;
-                            } else if (year) {
-                              formattedDate = year.toString();
-                            } else {
-                              formattedDate = 'Date Unknown. ';
-                            }
-                            
-                          } else {
-                            date = 'Date Unknown. ';
-                          }
+
+                        if (!date) {
+                            date = date_created;
+                        }
+                      
+                        var formattedDate = '';
+                        var month = dateObj.getAbbreviatedMonthName();
+                        var day = dateObj.getDate();
+                        var year = dateObj.getFullYear();
+                        
+                        if (month && day && year) {
+                          formattedDate = month + ' ' + day + ', ' + year + '. ';
+                        } else if (month && year) {
+                          formattedDate = month + ' ' + year + '. ';
+                        } else if (day && year) {
+                          formattedDate = day + ', ' + year + '. ';
+                        } else if (year) {
+                          formattedDate = year.toString();
+                        } else {
+                          formattedDate = 'Date Unknown. ';
+                        }
                           
-                          date = formattedDate + '. ';
+                          date = formattedDate;
                           collection = collection + '. ';
                           source = source + '. ';
                           repo = ' ' + repo + ', ';

--- a/app/views/items/_cite_panel.html.haml
+++ b/app/views/items/_cite_panel.html.haml
@@ -14,8 +14,10 @@
         %div{"data-item-id": "#{item.repository_id}"}
           = hidden_field_tag('dl-citation-author', item.element(:creator)&.value)
           = hidden_field_tag('dl-citation-collection', item.collection.title)
-          = hidden_field_tag('dl-citation-date-created', item.created_at.iso8601)
-          = hidden_field_tag('dl-citation-date', item.date.utc.iso8601)
+          - if item.date
+            = hidden_field_tag('dl-citation-date', item.date.utc.iso8601)
+          - else 
+            = hidden_field_tag('dl-citation-date-created', item.created_at.iso8601)
           = hidden_field_tag('dl-citation-source',
                              Setting::string(Setting::Keys::ORGANIZATION_NAME))
           = hidden_field_tag('dl-citation-title', item.title)


### PR DESCRIPTION
This addresses changes for issue [55](https://github.com/medusa-project/digital-library-issues/issues/55#issuecomment-2147747162) that broke some features on demo. 

Client noticed that certain collection items without a date of historical item were not accessible anymore. 

This item without a date renders an error: https://demo.digital.library.illinois.edu/items/7bfaab10-0b13-0134-1d55-0050569601ca-8

![image](https://github.com/medusa-project/kumquat/assets/103534307/ffa9e24e-c46a-4dec-9f7f-335d8506737d)

This item inside the same collection, but WITH a date works fine:
https://demo.digital.library.illinois.edu/items/7f052a90-0b13-0134-1d55-0050569601ca-c
<img width="1042" alt="Screenshot 2024-06-06 at 9 33 56 AM" src="https://github.com/medusa-project/kumquat/assets/103534307/eed33909-e3c5-42e7-b4e8-16d62129013b">

Summary of Changes to fix the error:

- updated the cite modal inside` _cite_panel.html.haml` with conditional so only if a historical date for an item exists it will pull from the item's date, thereby preventing an error being thrown when such a date doesn't exist
- updated the logic inside `assets/javascripts/items.js` -> `const CitationPanel` function to handle a scenario where no date is available at all, and reformatted how the date is populated in each citation

Tested Locally:

- Now items without a historical date are accessible again, and their citations are now in the correct format displaying that they don't have a date:



<img width="1054" alt="Screenshot 2024-06-06 at 9 39 37 AM" src="https://github.com/medusa-project/kumquat/assets/103534307/015acc9c-997d-492e-8c96-4af5a3be8e3a">
