### PR TITLE
Feature/DLD 115

### DIFF
--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -477,6 +477,10 @@ const Application = {
 
 };
 
+$(document).ready(function(){
+  $('[data-toggle="tooltip"]').tooltip();
+});
+
 var ready = function() {
     Application.init();
 };

--- a/app/views/collections/_description.html.haml
+++ b/app/views/collections/_description.html.haml
@@ -26,7 +26,10 @@
   - if @collection.physical_collection_url.present?
     = link_to(@collection.physical_collection_url,
               class: 'btn btn-lg btn-outline-primary',
-              target: '_blank') do 
+              target: '_blank',
+              'aria-label': 'Full Collection Description, opens new window',
+              data: {toggle: 'tooltip', placement: 'top'},
+              title: 'Opens new window') do 
       = 'Full Collection Description'
       %i.fa.fa-external-link-alt
 

--- a/app/views/collections/_description.html.haml
+++ b/app/views/collections/_description.html.haml
@@ -28,7 +28,7 @@
               class: 'btn btn-lg btn-outline-primary',
               target: '_blank',
               'aria-label': 'Full Collection Description, opens new window',
-              data: {toggle: 'tooltip', placement: 'top'},
+              data: {toggle: 'tooltip', placement: 'right'},
               title: 'Opens new window') do 
       = 'Full Collection Description'
       %i.fa.fa-external-link-alt


### PR DESCRIPTION
This PR addresses [issue 115](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=65894774), related to [issue 89](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=62765564) 

_Adding a Tooltip to explain that clicking on the Full Collection Description button will take the user to a new window_

Summary of Changes:

- add `tooltip toggle function` inside `kumquat.js` 
- add `'aria-label'` element inside` _description.html.haml` within `physical_collection` block
  - allows `screen reader` to describe that the link will open in a new window
- call on `tooltip toggle function` and set `placement on the right` side of the button

Screencasts of how this functionality works with a screenreader (both using a mouse and tabbing on keyboard):



https://github.com/medusa-project/kumquat/assets/103534307/5e0d5578-e002-4fa2-a108-29f2e5a17844



https://github.com/medusa-project/kumquat/assets/103534307/5cd7c57a-8194-4a22-b7d3-f919ccd4c972

