### PR TITLE
Feature/DLD 63 - Rights Description Display

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -879,25 +879,17 @@ class Item < ApplicationRecord
   # drawn from some controlled vocabulary.
   #
   # @return [String, nil] Rights statement assigned to the instance, if
-  #                       present; otherwise, the closest ancestor statement,
-  #                       if present; otherwise, the rights statement assigned
-  #                       to its collection, if present; otherwise nil.
+  #                       present; otherwise, rights description,
+  #                       if present; otherwise nil.
   # @see effective_rights_term
   #
   def effective_rights_statement
     # Use the statement assigned to the instance.
     rs = self.elements.find{ |e| e.name == 'rights' && e.value.present? }&.value
-    # If not available, walk up the item tree to find a parent statement.
+    # if no rights value, map through elments to retrieve accessRights value
     if rs.blank?
-      p = self.parent
-      while p
-        rs = p.elements.find{ |e| e.name == 'rights' && e.value.present? }&.value
-        break if rs.present?
-        p = p.parent
-      end
+      rs = self.elements.find{ |e| e.name == 'accessRights' && e.value.present? }&.value 
     end
-    # If still no statement available, use the collection's statement.
-    rs = self.collection.rights_statement if rs.blank?
     rs
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -878,8 +878,8 @@ class Item < ApplicationRecord
   # {effective_rights_term}) in that the statement is free-form and the term is
   # drawn from some controlled vocabulary.
   #
-  # @return [String, nil] Rights statement assigned to the instance, if
-  #                       present; otherwise, rights description,
+  # @return [String, nil] Rights description assigned to the instance, if
+  #                       present; otherwise, rights statement,
   #                       if present; otherwise nil.
   # @see effective_rights_term
   #

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -884,11 +884,11 @@ class Item < ApplicationRecord
   # @see effective_rights_term
   #
   def effective_rights_statement
-    # Use the statement assigned to the instance.
-    rs = self.elements.find{ |e| e.name == 'rights' && e.value.present? }&.value
     # if no rights value, map through elments to retrieve accessRights value
+    rs = self.elements.find{ |e| e.name == 'accessRights' && e.value.present? }&.value 
+    # Use the statement assigned to the instance.
     if rs.blank?
-      rs = self.elements.find{ |e| e.name == 'accessRights' && e.value.present? }&.value 
+      rs = self.elements.find{ |e| e.name == 'rights' && e.value.present? }&.value
     end
     rs
   end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -884,9 +884,9 @@ class Item < ApplicationRecord
   # @see effective_rights_term
   #
   def effective_rights_statement
-    # if no rights value, map through elments to retrieve accessRights value
+    # iterate through elments to retrieve rights description value
     rs = self.elements.find{ |e| e.name == 'accessRights' && e.value.present? }&.value 
-    # Use the statement assigned to the instance.
+    # if blank, iterate through elements to retrieve the statement assigned to the instance.
     if rs.blank?
       rs = self.elements.find{ |e| e.name == 'rights' && e.value.present? }&.value
     end

--- a/test/models/item_test.rb
+++ b/test/models/item_test.rb
@@ -397,24 +397,9 @@ class ItemTest < ActiveSupport::TestCase
 
   # effective_rights_statement()
 
-  test 'effective_rights_statement() returns the statement of the instance' do
+  test 'effective_rights_statement() returns the rights description of the instance' do
     @item = items(:compound_object_1001)
     assert_equal 'Sample Rights', @item.effective_rights_statement
-  end
-
-  test 'effective_rights_statement() should fall back to a parent statement' do
-    @item.collection.rights_statement = "cats"
-    @item.elements.destroy_all
-    assert_equal @item.collection.rights_statement,
-                 @item.effective_rights_statement
-  end
-
-  test 'effective_rights_statement() should fall back to the collection
-  rights statement' do
-    @item.elements.destroy_all
-    @item.save
-    @item.collection.rights_statement = 'cats'
-    assert_equal 'cats', @item.effective_rights_statement
   end
 
   # effective_rights_term()


### PR DESCRIPTION
Addresses Issue [63](https://github.com/orgs/medusa-project/projects/2?pane=issue&itemId=35597240) - rights description should be displayed next to copyright icon. 

Summary of Changes:
- inside `Item model`: 
- `effective_rights_statement` first looks for the rights description value (ie. `accessRights`), if present. 
- if that value is blank, it then defaults to the rights statement value (ie. `Rights`). 
- for items that don't have any metadata for accessRights and Rights, nothing changes in the display.


<img width="1140" alt="Screenshot 2024-07-09 at 9 21 54 AM" src="https://github.com/medusa-project/kumquat/assets/103534307/c5544c48-e0a2-4a38-b275-6f5e9ce0c434">

- if an item has a copyright, it should theoretically have a rights description. If the item specifically says `No Copyright,` that data is being retrieved from the rights value. 

<img width="475" alt="Screenshot 2024-07-09 at 9 28 09 AM" src="https://github.com/medusa-project/kumquat/assets/103534307/fa187919-55aa-48ee-961f-74439009ee3b">



