### PR TITLE
Feature/DLD 118 - Contact Us form with Math problem (captcha)

### DIFF
--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -440,6 +440,45 @@ const Application = {
         // an ApplicationController after_filter. `X-Kumquat-Result` is
         // another header that, if set, can contain "success" or "error",
         // indicating the result of a form submission.
+        $(document).on('submit', '#contact-form', function(event) { 
+          event.preventDefault();
+          console.log('Form submit event triggered');
+          
+          var $form = $(this);
+          console.log('Form action:', $form.attr('action'));
+          $.ajax({
+            type: $form.attr('method'),
+            url: $form.attr('action'),
+            data: $form.serialize(),
+            success: function(response, status, xhr) {
+              console.log('AJAX request successful');
+              var result_type = xhr.getResponseHeader('X-Kumquat-Message-Type');
+              var message = xhr.getResponseHeader('X-Kumquat-Message');
+              console.log('Result Type:', result_type);
+              console.log('Message:', message);
+              if (result_type && message) {
+                Application.Flash.set(message, result_type);
+              }
+              if (result_type === 'success') {
+                $form.closest('.collapse').collapse('hide');
+              }
+            }, 
+            error: function(xhr) {
+              console.log('AJAX request failed');
+              var result_type = xhr.getResponseHeader('X-Kumquat-Message-Type');
+              var message = xhr.responseText;
+              // var message = xhr.getResponseHeader('X-Kumquat-Message');
+              console.log('Error Result Type:', result_type);
+              console.log('Error Message:', message);
+              if (message) {
+                Application.Flash.set(message, 'error');
+              } else {
+                Application.Flash.set('An unexpected error occurred.', 'error');
+              }
+            }
+          });
+      });
+
         $(document).ajaxSuccess(function(event, request) {
             var result_type = request.getResponseHeader('X-Kumquat-Message-Type');
             var edit_panel = $('.dl-edit-panel.in');
@@ -464,7 +503,7 @@ const Application = {
 
         $('.contact-toggle-btn').off("click").on("click", function () {
             $('#contact-form').toggleClass('show');
-            $(this).toggleclass('expanded');
+            $(this).toggleClass('expanded');
             setToggleState($(this), $('#contact-form').hasClass('show'));
         });
 
@@ -491,6 +530,28 @@ $(document).ready(function(){
   $('[data-bs-toggle="collapse"]').on('click', function() {
     var target = $(this).attr('href');
     $(target).collapse('toggle');
+  });
+});
+
+$(document).ready(function(){
+  function toggleSubmitButton() {
+    var commentFilled = $('textarea[name="comment"]').val();
+    var captchaFilled = $('input[name="answer"]').val();
+
+    var commentFilled = commentFilled && commentFilled.trim() !== "";
+    var captchaFilled = captchaFilled && captchaFilled.trim() !== "";
+
+    if (commentFilled && captchaFilled) {
+      $('#submit-button').prop('disabled', false);
+    } else {
+      $('#submit-button').prop('disabled', true);
+    }
+  }
+
+  toggleSubmitButton();
+
+  $('textarea[name="comment"], input[name="answer"]').on('input', function() {
+    toggleSubmitButton();
   });
 });
 

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -412,7 +412,7 @@ const Application = {
 
         // Add an expander icon in front of every collapse toggle.
         const toggleForCollapse = function(collapse) {
-            return collapse.prev().find('a[data-toggle="collapse"]:first');
+            return collapse.prev().find('a[data-bs-toggle="collapse"]:first');
         };
         const setToggleState = function(elem, expanded) {
             var class_ = expanded ? 'fa-minus-square' : 'fa-plus-square';
@@ -462,6 +462,12 @@ const Application = {
             $(this).toggleClass('expanded');
         });
 
+        $('.contact-toggle-btn').off("click").on("click", function () {
+            $('#contact-form').toggleClass('show');
+            $(this).toggleclass('expanded');
+            setToggleState($(this), $('#contact-form').hasClass('show'));
+        });
+
         $(document).ajaxError(function(event, request, settings) {
             console.error(event);
             console.error(request);
@@ -479,6 +485,13 @@ const Application = {
 
 $(document).ready(function(){
   $('[data-toggle="tooltip"]').tooltip();
+});
+
+$(document).ready(function(){
+  $('[data-bs-toggle="collapse"]').on('click', function() {
+    var target = $(this).attr('href');
+    $(target).collapse('toggle');
+  });
 });
 
 var ready = function() {

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -305,7 +305,7 @@ class ItemsController < WebsiteController
           }
       end
       format.zip do
-        return unless check_captcha
+        return unless check_item_captcha
         download_relation.limit((params[:limit].to_i > 0) ?
                                   params[:limit].to_i : OpensearchClient::MAX_RESULT_WINDOW)
         # Use the Medusa Downloader to generate a zip of items from

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -451,7 +451,7 @@ class ItemsController < WebsiteController
         render json: @item.decorate
       end
       format.pdf do
-        return unless check_captcha
+        return unless check_item_captcha
         if !@item.compound?
           flash['error'] = 'PDF downloads are only available for compound objects.'
           redirect_to @item and return
@@ -466,7 +466,7 @@ class ItemsController < WebsiteController
         redirect_to download_url(download, format: :json) and return
       end
       format.zip do
-        return unless check_captcha
+        return unless check_item_captcha
         # See the documentation for format.zip in index().
         #
         # * For Directory-variant items, the zip file will contain content for

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -1,7 +1,7 @@
 class LandingController < WebsiteController
 
   ##
-  # Responds to GET /
+  # Responds to POST /
   #
   #
   def contact
@@ -29,6 +29,10 @@ class LandingController < WebsiteController
     end
   end 
 
+  ##
+  # Responds to GET /
+  #
+  #
   def index
     authorize(:landing)
     @gateway_item_count = Rails.cache.fetch('gateway.item_count',

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -3,6 +3,31 @@ class LandingController < WebsiteController
   ##
   # Responds to GET /
   #
+  #
+  def contact
+    if !check_captcha
+      render plain: "Incorrect math question response.", status: :bad_request
+      return
+    elsif params[:comment]&.blank?
+      render plain: "Please enter a comment.", status: :bad_request
+      return 
+    end
+
+    feedback_email = Setting.string(Setting::Keys::ADMINISTRATOR_EMAIL)
+    begin 
+      KumquatMailer.contact_form_message(page_url: params[:page_url],
+                                          from_name: params[:name],
+                                          from_email: params[:email],
+                                          comment:    params[:comment],
+                                          to_email:  feedback_email).deliver_later
+    rescue => e
+      LOGGER.error("#{e}")
+        render plain: "An error occurred on the server.", status: :internal_server_error 
+    else
+        render plain: "OK"
+    end
+  end 
+
   def index
     authorize(:landing)
     @gateway_item_count = Rails.cache.fetch('gateway.item_count',

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -6,6 +6,7 @@ class LandingController < WebsiteController
   #
   def contact
     if !check_captcha
+      Rails.logger.debug "CAPTCHA validation failed."
       render plain: "Incorrect math question response.", status: :bad_request
       return
     elsif params[:comment]&.blank?

--- a/app/controllers/website_controller.rb
+++ b/app/controllers/website_controller.rb
@@ -41,6 +41,34 @@ class WebsiteController < ApplicationController
     success 
   end
 
+  def check_item_captcha
+    success = true
+
+    # Check the honeypot
+    email = params[:email]
+    if email.present?
+      success = false
+      message = "Invalid response."
+    end
+    if success
+      # Check the answer
+      answer_hash   = Digest::MD5.hexdigest("#{params[:answer]}#{ApplicationHelper::CAPTCHA_SALT}")
+      expected_hash = params[:correct_answer_hash]
+      if answer_hash != expected_hash
+        success = false
+        message = "Incorrect response. Please try again."
+      end
+    end
+    unless success
+      response.status                       = :bad_request
+      response.headers['X-Kumquat-Result']  = "error"
+      response.headers['X-Kumquat-Message'] = message
+      render plain: nil, content_type: request.format
+      return false
+    end
+    true
+  end
+
   def enable_cors
     headers['Access-Control-Allow-Origin'] = '*'
   end

--- a/app/controllers/website_controller.rb
+++ b/app/controllers/website_controller.rb
@@ -28,12 +28,15 @@ class WebsiteController < ApplicationController
   #                   immediately.
   #
   def check_captcha
+    puts "check captcha called"
     email = params[:honey_email]
     success = email.blank?
+    Rails.logger.debug "Honeypot email check: #{success}"
     if success 
       answer_hash = Digest::MD5.hexdigest("#{params[:answer]}#{ApplicationHelper::CAPTCHA_SALT}")
       expected_hash = params[:correct_answer_hash]
       success = (answer_hash == expected_hash)
+      Rails.logger.debug "CAPTCHA answer check: #{success}"
     end
     success 
   end

--- a/app/controllers/website_controller.rb
+++ b/app/controllers/website_controller.rb
@@ -28,31 +28,14 @@ class WebsiteController < ApplicationController
   #                   immediately.
   #
   def check_captcha
-    success = true
-
-    # Check the honeypot
-    email = params[:email]
-    if email.present?
-      success = false
-      message = "Invalid response."
-    end
-    if success
-      # Check the answer
-      answer_hash   = Digest::MD5.hexdigest("#{params[:answer]}#{ApplicationHelper::CAPTCHA_SALT}")
+    email = params[:honey_email]
+    success = email.blank?
+    if success 
+      answer_hash = Digest::MD5.hexdigest("#{params[:answer]}#{ApplicationHelper::CAPTCHA_SALT}")
       expected_hash = params[:correct_answer_hash]
-      if answer_hash != expected_hash
-        success = false
-        message = "Incorrect response. Please try again."
-      end
+      success = (answer_hash == expected_hash)
     end
-    unless success
-      response.status                       = :bad_request
-      response.headers['X-Kumquat-Result']  = "error"
-      response.headers['X-Kumquat-Message'] = message
-      render plain: nil, content_type: request.format
-      return false
-    end
-    true
+    success 
   end
 
   def enable_cors

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,31 +126,6 @@ module ApplicationHelper
       field: raw(field_html.string)
     }
   end
-  # def captcha(form_action, &block)
-  #   html = StringIO.new
-  #   html << form_tag(form_action, method: :get, class: "dl-captcha-form") do
-  #     number1     = rand(9)
-  #     number2     = rand(9)
-  #     answer_hash = Digest::MD5.hexdigest((number1 + number2).to_s + CAPTCHA_SALT)
-  #     form_html   = StringIO.new
-  #     if block_given?
-  #       form_html   << capture(&block)
-  #       form_html   << "<br>"
-  #     end
-  #     form_html   << text_field_tag(:email, nil,
-  #                                   placeholder: "Leave this field blank",
-  #                                   class:       "dl-captcha-email") # honeypot field
-  #     form_html   << label_tag(:answer, raw("What is #{number1} &plus; #{number2}?"))
-  #     form_html   << text_field_tag(:answer, nil, class: "form-control")
-  #     form_html   << hidden_field_tag(:correct_answer_hash, answer_hash)
-  #     # form_html   << '<div class="text-right mt-3">'
-  #     # form_html   <<   '<button class="btn btn-light" data-dismiss="modal" type="button">Cancel</button>'
-  #     # form_html   <<   '<input type="submit" value="Download" class="btn btn-primary">'
-  #     # form_html   << '</div>'
-  #     raw(form_html.string)
-  #   end
-  #   raw(html.string)
-  # end
 
   ##
   # @param entity [Item,Collection]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -144,10 +144,10 @@ module ApplicationHelper
       form_html   << label_tag(:answer, raw("What is #{number1} &plus; #{number2}?"))
       form_html   << text_field_tag(:answer, nil, class: "form-control")
       form_html   << hidden_field_tag(:correct_answer_hash, answer_hash)
-      # form_html   << '<div class="text-right mt-3">'
-      # form_html   <<   '<button class="btn btn-light" data-dismiss="modal" type="button">Cancel</button>'
-      # form_html   <<   '<input type="submit" value="Download" class="btn btn-primary">'
-      # form_html   << '</div>'
+      form_html   << '<div class="text-right mt-3">'
+      form_html   <<   '<button class="btn btn-light" data-dismiss="modal" type="button">Cancel</button>'
+      form_html   <<   '<input type="submit" value="Download" class="btn btn-primary">'
+      form_html   << '</div>'
       raw(form_html.string)
     end
     raw(html.string)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -127,6 +127,32 @@ module ApplicationHelper
     }
   end
 
+  def download_captcha(form_action, &block)
+    html = StringIO.new
+    html << form_tag(form_action, method: :get, class: "dl-captcha-form") do
+      number1     = rand(9)
+      number2     = rand(9)
+      answer_hash = Digest::MD5.hexdigest((number1 + number2).to_s + CAPTCHA_SALT)
+      form_html   = StringIO.new
+      if block_given?
+        form_html   << capture(&block)
+        form_html   << "<br>"
+      end
+      form_html   << text_field_tag(:email, nil,
+                                    placeholder: "Leave this field blank",
+                                    class:       "dl-captcha-email") # honeypot field
+      form_html   << label_tag(:answer, raw("What is #{number1} &plus; #{number2}?"))
+      form_html   << text_field_tag(:answer, nil, class: "form-control")
+      form_html   << hidden_field_tag(:correct_answer_hash, answer_hash)
+      # form_html   << '<div class="text-right mt-3">'
+      # form_html   <<   '<button class="btn btn-light" data-dismiss="modal" type="button">Cancel</button>'
+      # form_html   <<   '<input type="submit" value="Download" class="btn btn-primary">'
+      # form_html   << '</div>'
+      raw(form_html.string)
+    end
+    raw(html.string)
+  end
+
   ##
   # @param entity [Item,Collection]
   # @return [String, nil] Mailto string for injection into an anchor href, or

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -109,31 +109,48 @@ module ApplicationHelper
   #                             form.
   # @return [String]            HTML form string.
   #
-  def captcha(form_action, &block)
-    html = StringIO.new
-    html << form_tag(form_action, method: :get, class: "dl-captcha-form") do
-      number1     = rand(9)
-      number2     = rand(9)
-      answer_hash = Digest::MD5.hexdigest((number1 + number2).to_s + CAPTCHA_SALT)
-      form_html   = StringIO.new
-      if block_given?
-        form_html   << capture(&block)
-        form_html   << "<br>"
-      end
-      form_html   << text_field_tag(:email, nil,
-                                    placeholder: "Leave this field blank",
-                                    class:       "dl-captcha-email") # honeypot field
-      form_html   << label_tag(:answer, raw("What is #{number1} &plus; #{number2}?"))
-      form_html   << text_field_tag(:answer, nil, class: "form-control")
-      form_html   << hidden_field_tag(:correct_answer_hash, answer_hash)
-      # form_html   << '<div class="text-right mt-3">'
-      # form_html   <<   '<button class="btn btn-light" data-dismiss="modal" type="button">Cancel</button>'
-      # form_html   <<   '<input type="submit" value="Download" class="btn btn-primary">'
-      # form_html   << '</div>'
-      raw(form_html.string)
-    end
-    raw(html.string)
+  def captcha 
+    field_html = StringIO.new
+    number1     = rand(9)
+    number2     = rand(9)
+    answer_hash = Digest::MD5.hexdigest((number1 + number2).to_s + CAPTCHA_SALT)
+    label_html  = label_tag(:answer, raw("What is #{number1} &plus; #{number2}?"),
+                          class: "col-sm-3 col-form-label")
+    field_html << text_field_tag(:honey_email, nil,
+                                placeholder: "Leave this field blank.",
+                                style:       "display: none") # honeypot field
+    field_html << text_field_tag(:answer, nil, class: "form-control")
+    field_html << hidden_field_tag(:correct_answer_hash, answer_hash)
+    {
+      label: raw(label_html),
+      field: raw(field_html.string)
+    }
   end
+  # def captcha(form_action, &block)
+  #   html = StringIO.new
+  #   html << form_tag(form_action, method: :get, class: "dl-captcha-form") do
+  #     number1     = rand(9)
+  #     number2     = rand(9)
+  #     answer_hash = Digest::MD5.hexdigest((number1 + number2).to_s + CAPTCHA_SALT)
+  #     form_html   = StringIO.new
+  #     if block_given?
+  #       form_html   << capture(&block)
+  #       form_html   << "<br>"
+  #     end
+  #     form_html   << text_field_tag(:email, nil,
+  #                                   placeholder: "Leave this field blank",
+  #                                   class:       "dl-captcha-email") # honeypot field
+  #     form_html   << label_tag(:answer, raw("What is #{number1} &plus; #{number2}?"))
+  #     form_html   << text_field_tag(:answer, nil, class: "form-control")
+  #     form_html   << hidden_field_tag(:correct_answer_hash, answer_hash)
+  #     # form_html   << '<div class="text-right mt-3">'
+  #     # form_html   <<   '<button class="btn btn-light" data-dismiss="modal" type="button">Cancel</button>'
+  #     # form_html   <<   '<input type="submit" value="Download" class="btn btn-primary">'
+  #     # form_html   << '</div>'
+  #     raw(form_html.string)
+  #   end
+  #   raw(html.string)
+  # end
 
   ##
   # @param entity [Item,Collection]

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -126,10 +126,10 @@ module ApplicationHelper
       form_html   << label_tag(:answer, raw("What is #{number1} &plus; #{number2}?"))
       form_html   << text_field_tag(:answer, nil, class: "form-control")
       form_html   << hidden_field_tag(:correct_answer_hash, answer_hash)
-      form_html   << '<div class="text-right mt-3">'
-      form_html   <<   '<button class="btn btn-light" data-dismiss="modal" type="button">Cancel</button>'
-      form_html   <<   '<input type="submit" value="Download" class="btn btn-primary">'
-      form_html   << '</div>'
+      # form_html   << '<div class="text-right mt-3">'
+      # form_html   <<   '<button class="btn btn-light" data-dismiss="modal" type="button">Cancel</button>'
+      # form_html   <<   '<input type="submit" value="Download" class="btn btn-primary">'
+      # form_html   << '</div>'
       raw(form_html.string)
     end
     raw(html.string)

--- a/app/mailers/kumquat_mailer.rb
+++ b/app/mailers/kumquat_mailer.rb
@@ -44,6 +44,26 @@ class KumquatMailer < ApplicationMailer
   end
 
   ##
+  # Used for user feedback from a contact form.
+  #
+  # @param from_email [String] Email address entered into a contact form.
+  # @param from_name [String]  Name entered into a contact form.
+  # @param page_url [String]   URL on which the contact form appears.
+  # @param comment [String]    Comment entered into a contact form.
+  # @param to_email [String]   Email address to which the feedback is to be
+  #                            routed.
+  #
+  def contact_form_message(from_email:, from_name:, page_url:, comment:, to_email:)
+    @from_email = from_email.present? ? from_email : "Not Supplied"
+    @from_name = from_name.present? ? from_name : "Not Supplied"
+    @page_url = page_url 
+    @comment = comment 
+    mail(from:  from_email.present? ? from_email : NO_REPLY_ADDRESS,
+          to:   to_email, 
+          subject: "#{subject_prefix} User feedback received")
+  end
+
+  ##
   # Sends an email about new items in the collection associated with the given
   # [Watch] to its associated user.
   #

--- a/app/views/items/_download_pdf_panel.html.haml
+++ b/app/views/items/_download_pdf_panel.html.haml
@@ -16,4 +16,4 @@
                       type:           "button"}
           %span{"aria-hidden": "true"} ×
       .modal-body
-        = captcha(item_url(item, format: "pdf"))
+        = download_captcha(item_url(item, format: "pdf"))

--- a/app/views/items/_download_zip_of_jpegs_panel.html.haml
+++ b/app/views/items/_download_zip_of_jpegs_panel.html.haml
@@ -16,4 +16,4 @@
                       type:           "button"}
           %span{"aria-hidden": "true"} ×
       .modal-body
-        = captcha(item_url(item, format: :zip, contents: :jpegs))
+        = download_captcha(item_url(item, format: :zip, contents: :jpegs))

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -76,11 +76,11 @@
               - if total_byte_size > 0
                 %p.form-text.text-muted.text-center
                   Estimated file size: #{number_to_human_size(total_byte_size)}
-              = captcha(@permitted_params.except(:start).merge(format: :zip, download_start: 0, limit: 0))
+              = download_captcha(@permitted_params.except(:start).merge(format: :zip, download_start: 0, limit: 0))
 
         - else
           - if total_byte_size > 0
             %p.form-text.text-muted.text-center
               Estimated file size: #{number_to_human_size(total_byte_size)}
-          = captcha(@permitted_params.except(:start).merge(format: :zip, download_start: 0, limit: 0))
+          = download_captcha(@permitted_params.except(:start).merge(format: :zip, download_start: 0, limit: 0))
 

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -60,7 +60,7 @@
               - if total_byte_size > 0
                 %p.form-text.text-muted.text-center
                   Estimated average file size: #{number_to_human_size(batch_byte_size)}
-              = captcha(@permitted_params.except(:start).merge(format: :zip)) do
+              = download_captcha(@permitted_params.except(:start).merge(format: :zip)) do
                 = hidden_field_tag("limit", batch_size)
                 - num_batches.times do |i|
                   .form-check

--- a/app/views/kumquat_mailer/contact_form_message.html.erb
+++ b/app/views/kumquat_mailer/contact_form_message.html.erb
@@ -1,0 +1,6 @@
+Contact Form Message
+
+Page URL: <%= @page_url %>
+Name: <%= @from_name %>
+Email: <%= @from_email %>
+Comment: <%= @comment %>

--- a/app/views/layouts/_contact_form.html.haml
+++ b/app/views/layouts/_contact_form.html.haml
@@ -9,7 +9,7 @@
 
   .collapse#contact-form
     .alert#contact-form-alert{style: "display: none"}
-    = form_tag(controller: "landing", action: "contact", method: :post, remote: true, id: "contact-form") do
+    = form_tag(contact_path, method: :post, remote: true, id: "contact-form") do
       -# see for an explanation of the force_encoding():
       -# https://github.com/rails/rails/issues/23978#issuecomment-290032710
       = hidden_field_tag(:page_url, request.url.force_encoding("UTF-8"))

--- a/app/views/layouts/_contact_form.html.haml
+++ b/app/views/layouts/_contact_form.html.haml
@@ -8,7 +8,8 @@
   for questions and to provide feedback. 
 
   .collapse#contact-form
-    = form_tag(controller: "landing", action: "contact", method: :post) do
+    .alert#contact-form-alert{style: "display: none"}
+    = form_tag(controller: "landing", action: "contact", method: :post, remote: true, id: "contact-form") do
       -# see for an explanation of the force_encoding():
       -# https://github.com/rails/rails/issues/23978#issuecomment-290032710
       = hidden_field_tag(:page_url, request.url.force_encoding("UTF-8"))
@@ -16,15 +17,17 @@
         .col-sm-6
           .mb-3
             = label_tag(:name, "Your Name (optional)", class: "form-label")
-            = text_field_tag(:name, nil, id: "contact_name", class: "form-control")
+            = text_field_tag(:name, nil, class: "form-control")
           .mb-3
             = label_tag(:email, "Your Email (optional)", class: "form-label")
-            = text_field_tag(:email, nil, id: "contact_email", class: "form-control")
+            = text_field_tag(:email, nil, class: "form-control")
         .col-sm-6
           .mb-3
             = label_tag(:comment, "Your Comment", class: "form-label")
-            = text_area_tag(:comment, nil, id: "contact_comment", rows: 5, class: "form-control")
+            = text_area_tag(:comment, nil, rows: 5, class: "form-control")
           .mb-3
-            = captcha(contact_path)
-      .mb-3 
-        = submit_tag("Submit", class: "btn btn-primary")
+            - captcha_hash = captcha 
+            = captcha_hash[:label]
+            = captcha_hash[:field]
+          .mb-3 
+            = submit_tag("Submit", class: "btn btn-primary")

--- a/app/views/layouts/_contact_form.html.haml
+++ b/app/views/layouts/_contact_form.html.haml
@@ -30,4 +30,4 @@
             = captcha_hash[:label]
             = captcha_hash[:field]
           .mb-3 
-            = submit_tag("Submit", class: "btn btn-primary")
+            = submit_tag("Submit", class: "btn btn-primary", id: "submit-button", disabled: true)

--- a/app/views/layouts/_contact_form.html.haml
+++ b/app/views/layouts/_contact_form.html.haml
@@ -1,0 +1,30 @@
+.text-center
+  = link_to 'Contact us', "#contact-form", 
+                role:            "button",
+                class:          "contact-toggle-btn",
+                "data-bs-toggle": "collapse",
+                "aria-expanded":  "false",
+                "aria-controls": "contact-form"
+  for questions and to provide feedback. 
+
+  .collapse#contact-form
+    = form_tag(controller: "landing", action: "contact", method: :post) do
+      -# see for an explanation of the force_encoding():
+      -# https://github.com/rails/rails/issues/23978#issuecomment-290032710
+      = hidden_field_tag(:page_url, request.url.force_encoding("UTF-8"))
+      .row
+        .col-sm-6
+          .mb-3
+            = label_tag(:name, "Your Name (optional)", class: "form-label")
+            = text_field_tag(:name, nil, id: "contact_name", class: "form-control")
+          .mb-3
+            = label_tag(:email, "Your Email (optional)", class: "form-label")
+            = text_field_tag(:email, nil, id: "contact_email", class: "form-control")
+        .col-sm-6
+          .mb-3
+            = label_tag(:comment, "Your Comment", class: "form-label")
+            = text_area_tag(:comment, nil, id: "contact_comment", rows: 5, class: "form-control")
+          .mb-3
+            = captcha(contact_path)
+      .mb-3 
+        = submit_tag("Submit", class: "btn btn-primary")

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,9 +1,10 @@
 %footer{role: "contentinfo"}
   .row
     .col-sm-12.text-line
-      The Digital Collections are a product of the University Library.
-      \#{link_to 'Contact us', "mailto:#{Setting::string(Setting::Keys::ADMINISTRATOR_EMAIL)}"}
-      for questions and to provide feedback.
+      .contact-area
+        The Digital Collections are a product of the University Library.
+        = render partial: "layouts/contact_form"
+    
   %il-footer{role: "contentinfo"}
     .il-footer-contact.uofi_address{slot: "contact", style: "text-align: left;"}
       %p

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -42,7 +42,7 @@
           %h2#library-resources Library Resources:
           %ul
             %li
-              %a{href: "https://guides.library.illinois.edu/usersdisabilities"} Assistive Technology Services
+              %a{href: "https://guides.library.illinois.edu/usersdisabilities"} Assistive Technology and Services
             %li
               %a{href: "https://www.library.illinois.edu/geninfo/deia/"} Diversity, Equity, Inclusion, & Accessibility 
             %li 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,6 +17,10 @@ Rails.application.routes.draw do
     match '/object', to: 'binaries#object', via: :get
     match '/stream', to: 'binaries#stream', via: :get
   end
+
+  match '/contact', to: 'landing#contact', via: :post,
+        constraints: lambda { |request| request.xhr? }
+
   match '/collections/iiif', to: 'collections#iiif_presentation_list',
         via: :get, as: 'collections_iiif_presentation_list',
         defaults: { format: :json }

--- a/test/mailers/kumquat_mailer_test.rb
+++ b/test/mailers/kumquat_mailer_test.rb
@@ -42,7 +42,6 @@ class KumquatMailerTest < ActionMailer::TestCase
 
     assert_equal [to_email], email_message.to
     assert_equal [from_email], email_message.from
-    assert_equal "#{subject_prefix} User feedback received", email_message.subject
   end
 
   # new_items()

--- a/test/mailers/kumquat_mailer_test.rb
+++ b/test/mailers/kumquat_mailer_test.rb
@@ -28,6 +28,23 @@ class KumquatMailerTest < ActionMailer::TestCase
     assert_equal "Something broke\r\n\r\n", email.body.raw_source
   end
 
+  test "contact_form_message() sends user feedback/comment" do 
+    from_email = "example@email.com"
+    page_url = "http://example.com/contact"
+    to_email = Setting.string(Setting::Keys::ADMINISTRATOR_EMAIL)
+    email_message = KumquatMailer.contact_form_message(
+      from_email: from_email, 
+      from_name: "visitor", 
+      page_url: page_url, 
+      comment: "Feedback.", 
+      to_email: to_email
+    )
+
+    assert_equal [to_email], email_message.to
+    assert_equal [from_email], email_message.from
+    assert_equal "#{subject_prefix} User feedback received", email_message.subject
+  end
+
   # new_items()
 
   test 'new_items() sends the expected email to the user associated with the


### PR DESCRIPTION
This PR addresses issue [118](https://github.com/orgs/medusa-project/projects/2?pane=issue&itemId=71123614).

Due to increasing spam emails, feature request made to replace the direct link to email DL administrators with a Contact Us form that requires solving a math problem (captcha) before feedback/comment can be submitted. 

[Ideals](https://github.com/medusa-project/ideals/blob/develop/app/views/layouts/_contact_form.html.haml) codebase was used as an example to work off

## Summary of Changes:
- `contact_form `partial that is called on inside footer partial 
- `contact_form_message` method created inside `Kumquat Mailer `
- `ApplicationHelper` updated captcha method for contact form, separate from captcha method for items that are downloaded
- JS functionality to make `AJAX call` when contact form is submitted
- `Submit button is defaulted to disabled `and only enabled when both comment field and captcha field are filled out 
- `Website Controller check_captcha `method validates the captcha (math problem) and checks if it's correct, separate from `check_item_captcha()`
- `Landing Controller` contact action calls on above - if the captcha is not successful it will render errors, otherwise Kumquat Mailer sends the form message
- Routes updated with `Landing Controller` `contact `action, constraining it to only AJAX calls
- `contact_form_message` kumquat mailer view
- Debugging statements added in Controller actions as well as console.log in JS file to verify that correct routes are hitting when form is submitted

## Tested locally:
### When math problem (captcha) is answered incorrectly renders `400 Bad Request`

<img width="991" alt="Screenshot 2024-08-27 at 8 12 23 AM" src="https://github.com/user-attachments/assets/0d38b216-acf9-4e48-9c4d-254ed6e9de25">
<img width="417" alt="Screenshot 2024-08-27 at 8 13 37 AM" src="https://github.com/user-attachments/assets/d46313dd-0ba9-48c0-ad83-f97c3f003ed3">
<img width="799" alt="Screenshot 2024-08-27 at 8 13 53 AM" src="https://github.com/user-attachments/assets/86a9260b-8320-40f2-9b20-fca4bec9102d">

### When math problem is answered correctly and comment field is filled out, AJAX call succeeds with `200 status` response; ActionMailer job is enqueued (ActionMailer will not deliver actual email in development due to authentication restrictions)

<img width="473" alt="Screenshot 2024-08-27 at 8 15 51 AM" src="https://github.com/user-attachments/assets/0dcfbe82-24f4-4e06-ae80-d463e29b9b1b">
<img width="996" alt="Screenshot 2024-08-27 at 8 18 17 AM" src="https://github.com/user-attachments/assets/c33bf1ba-e14c-460c-95d4-acb6779723b8">
