### PR TITLE
Issue 79 - Accessible coloring for collections table (admin interface)

### DIFF
--- a/app/assets/stylesheets/admin/application.scss
+++ b/app/assets/stylesheets/admin/application.scss
@@ -25,3 +25,20 @@
 @import "admin/metadata_profiles";
 @import "admin/settings";
 @import "admin/tasks";
+
+/* Custom overrides */
+// .text-success {
+//   color: white !important;
+// }
+
+// .text-danger {
+//   color: white !important;
+// }
+
+// .bg-success {
+//   background-color: darkblue !important;
+// }
+
+// .bg-danger {
+//   background-color: darkorange !important;
+// }

--- a/app/views/admin/collections/_collections.html.haml
+++ b/app/views/admin/collections/_collections.html.haml
@@ -18,15 +18,15 @@
         %td= link_to col.title, admin_collection_path(col)
         %td= number_with_delimiter(col.num_objects)
         %td= number_with_delimiter(col.num_items)
-        %td{class: "text-center #{col.public_in_medusa ? 'bg-success' : 'bg-danger'}"}
+        %td{class: "text-center #{col.public_in_medusa ? 'success' : 'danger'}"}
           = boolean(col.public_in_medusa)
-        %td{class: "text-center #{col.published_in_dls ? 'bg-success' : 'bg-danger'}"}
+        %td{class: "text-center #{col.published_in_dls ? 'success' : 'danger'}"}
           = boolean(col.published_in_dls)
-        %td{class: "text-center #{col.harvestable ? 'bg-success' : 'bg-danger'}"}
+        %td{class: "text-center #{col.harvestable ? 'success' : 'danger'}"}
           = boolean(col.harvestable)
-        %td{class: "text-center #{col.harvestable_by_idhh ? 'bg-success' : 'bg-danger'}"}
+        %td{class: "text-center #{col.harvestable_by_idhh ? 'success' : 'danger'}"}
           = boolean(col.harvestable_by_idhh)
-        %td{class: "text-center #{col.harvestable_by_primo ? 'bg-success' : 'bg-danger'}"}
+        %td{class: "text-center #{col.harvestable_by_primo ? 'success' : 'danger'}"}
           = boolean(col.harvestable_by_primo)
 .row.justify-content-md-center
   .col-md-auto


### PR DESCRIPTION
Addresses[ issue 79 ](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=41267919) - accessibility for admin interface collections table

**Summary of Changes**
- Removed the red/green block coloring
- Defaulted to icons to indicate true/false (the icons are default green/red to indicate success/failure) for ease of viewing 
- Comments out some custom overrides for now, but if we decide we do want color blocks again we can add those back in

<img width="1005" alt="Screenshot 2024-09-30 at 9 52 33 AM" src="https://github.com/user-attachments/assets/6e4610c2-4097-4ab4-a730-f37e02e1f5a4">
