### PR TITLE
Contact form changes

### DIFF
--- a/app/assets/javascripts/items.js
+++ b/app/assets/javascripts/items.js
@@ -473,6 +473,46 @@ const DLItemView = function() {
         new CitationPanel();
         new CustomImagePanel();
         new Application.CaptchaProtectedDownload();
+
+    $(document).ready(function(){
+      function toggleSubmitButton() {
+        var commentFilled = $('textarea[name="comment"]').val();
+        var captchaField = $('#contact-answer');
+        var captchaFilled = captchaField.val();
+
+        console.log('Comment:', commentFilled);
+        console.log('Captcha Field:', captchaField);
+        console.log('Captcha Field Exists:', captchaField.length > 0);
+        console.log('Captcha Value:', captchaFilled);
+
+        var commentFilled = commentFilled && commentFilled.trim() !== "";
+        var captchaFilled = captchaFilled && captchaFilled.trim() !== "";
+
+        if (commentFilled && captchaFilled) {
+          $('#submit-button').prop('disabled', false);
+        } else {
+          $('#submit-button').prop('disabled', true);
+        }
+      }
+
+      toggleSubmitButton();
+
+      $('textarea[name="comment"], #contact-answer').on('input', function () {
+        console.log('Input event triggered');
+        toggleSubmitButton();
+      });
+
+      // Ensure the form is reset when the document is ready
+      var form = $('#contact-form');
+      if (form) {
+        console.log('Resetting contact form');
+        form.reset();
+      } else {
+        console.log('Contact form not found');
+      }
+
+    });
+
     };
 
 };

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -441,43 +441,45 @@ const Application = {
         // another header that, if set, can contain "success" or "error",
         // indicating the result of a form submission.
         $(document).on('submit', '#contact-form', function(event) { 
-          event.preventDefault();
+          // event.preventDefault();
           console.log('Form submit event triggered');
           
           var $form = $(this);
           console.log('Form action:', $form.attr('action'));
-          $.ajax({
-            type: $form.attr('method'),
-            url: $form.attr('action'),
-            data: $form.serialize(),
-            success: function(response, status, xhr) {
-              console.log('AJAX request successful');
-              var result_type = xhr.getResponseHeader('X-Kumquat-Message-Type');
-              var message = xhr.getResponseHeader('X-Kumquat-Message');
-              console.log('Result Type:', result_type);
-              console.log('Message:', message);
-              if (result_type && message) {
-                Application.Flash.set(message, result_type);
-              }
-              if (result_type === 'success') {
-                $form.closest('.collapse').collapse('hide');
-              }
-            }, 
-            error: function(xhr) {
-              console.log('AJAX request failed');
-              var result_type = xhr.getResponseHeader('X-Kumquat-Message-Type');
-              var message = xhr.responseText;
-              // var message = xhr.getResponseHeader('X-Kumquat-Message');
-              console.log('Error Result Type:', result_type);
-              console.log('Error Message:', message);
-              if (message) {
-                Application.Flash.set(message, 'error');
-              } else {
-                Application.Flash.set('An unexpected error occurred.', 'error');
-              }
-            }
-          });
-      });
+        });
+
+      //     $.ajax({
+      //       type: $form.attr('method'),
+      //       url: $form.attr('action'),
+      //       data: $form.serialize(),
+      //       success: function(response, status, xhr) {
+      //         console.log('AJAX request successful');
+      //         var result_type = xhr.getResponseHeader('X-Kumquat-Message-Type');
+      //         var message = xhr.getResponseHeader('X-Kumquat-Message');
+      //         console.log('Result Type:', result_type);
+      //         console.log('Message:', message);
+      //         if (result_type && message) {
+      //           Application.Flash.set(message, result_type);
+      //         }
+      //         if (result_type === 'success') {
+      //           $form.closest('.collapse').collapse('hide');
+      //         }
+      //       }, 
+      //       error: function(xhr) {
+      //         console.log('AJAX request failed');
+      //         var result_type = xhr.getResponseHeader('X-Kumquat-Message-Type');
+      //         var message = xhr.responseText;
+      //         // var message = xhr.getResponseHeader('X-Kumquat-Message');
+      //         console.log('Error Result Type:', result_type);
+      //         console.log('Error Message:', message);
+      //         if (message) {
+      //           Application.Flash.set(message, 'error');
+      //         } else {
+      //           Application.Flash.set('An unexpected error occurred.', 'error');
+      //         }
+      //       }
+      //     });
+      // });
 
         $(document).ajaxSuccess(function(event, request) {
             var result_type = request.getResponseHeader('X-Kumquat-Message-Type');
@@ -515,14 +517,16 @@ const Application = {
         });
     },
 
-    /**
-     * @return An object representing the current view.
-     */
-    view: null
+    // /**
+    //  * @return An object representing the current view.
+    //  */
+    // view: null
 
 };
 
 $(document).ready(function(){
+  $('[#contact-form').reset();
+  
   $('[data-toggle="tooltip"]').tooltip();
 });
 

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -520,13 +520,15 @@ const Application = {
     // /**
     //  * @return An object representing the current view.
     //  */
-    // view: null
+    view: null
 
 };
 
 $(document).ready(function(){
-  $('[#contact-form').reset();
-  
+  var form = $('#contact-form')[0];
+  if (form) {
+    form.reset();
+  }
   $('[data-toggle="tooltip"]').tooltip();
 });
 
@@ -540,7 +542,7 @@ $(document).ready(function(){
 $(document).ready(function(){
   function toggleSubmitButton() {
     var commentFilled = $('textarea[name="comment"]').val();
-    var captchaFilled = $('input[name="answer"]').val();
+    var captchaFilled = $('#contact-answer').val();
 
     var commentFilled = commentFilled && commentFilled.trim() !== "";
     var captchaFilled = captchaFilled && captchaFilled.trim() !== "";
@@ -554,7 +556,7 @@ $(document).ready(function(){
 
   toggleSubmitButton();
 
-  $('textarea[name="comment"], input[name="answer"]').on('input', function() {
+  $('textarea[name="comment"], #contact-answer').on('input', function() {
     toggleSubmitButton();
   });
 });

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -7,11 +7,11 @@ class LandingController < WebsiteController
   def contact
     if !check_captcha
       Rails.logger.debug "CAPTCHA validation failed."
-      redirect_to root_path
+      redirect_to request.referer || root_path, notice: "FAILED to send. Incorrect math question response. Please try again."
       # render plain: "Incorrect math question response.", status: :bad_request
       return
     elsif params[:comment]&.blank?
-      redirect_to root_path, alert: "Enter comment."
+      redirect_to request.referer || root_path, alert: "Enter comment."
       # render plain: "Please enter a comment.", status: :bad_request
       return 
     end
@@ -25,14 +25,14 @@ class LandingController < WebsiteController
                                           to_email:  feedback_email).deliver_later
     rescue => e
       LOGGER.error("#{e}")
-      redirect_to root_path, alert: "An error occurred on the server."
+      redirect_to request.referer || root_path, alert: "An error occurred on the server."
         # render plain: "An error occurred on the server.", status: :internal_server_error 
     else
-      redirect_to root_path, notice: "Thank you for your feedback."  
+      redirect_to request.referer || root_path, notice: "Thank you for your feedback."  
       # render plain: "OK"
     end
   end 
-
+  
   ##
   # Responds to GET /
   #

--- a/app/controllers/landing_controller.rb
+++ b/app/controllers/landing_controller.rb
@@ -7,10 +7,12 @@ class LandingController < WebsiteController
   def contact
     if !check_captcha
       Rails.logger.debug "CAPTCHA validation failed."
-      render plain: "Incorrect math question response.", status: :bad_request
+      redirect_to root_path
+      # render plain: "Incorrect math question response.", status: :bad_request
       return
     elsif params[:comment]&.blank?
-      render plain: "Please enter a comment.", status: :bad_request
+      redirect_to root_path, alert: "Enter comment."
+      # render plain: "Please enter a comment.", status: :bad_request
       return 
     end
 
@@ -23,9 +25,11 @@ class LandingController < WebsiteController
                                           to_email:  feedback_email).deliver_later
     rescue => e
       LOGGER.error("#{e}")
-        render plain: "An error occurred on the server.", status: :internal_server_error 
+      redirect_to root_path, alert: "An error occurred on the server."
+        # render plain: "An error occurred on the server.", status: :internal_server_error 
     else
-        render plain: "OK"
+      redirect_to root_path, notice: "Thank you for your feedback."  
+      # render plain: "OK"
     end
   end 
 

--- a/app/views/items/_items.html.haml
+++ b/app/views/items/_items.html.haml
@@ -14,6 +14,10 @@
   .dl-no-results
     = no_results_help(params[:q], @suggestions)
 
+- unless defined?(@contact_form_rendered)
+  = render partial: 'layouts/contact_form'
+  - @contact_form_rendered = true 
+
 - if Rails.env.development?
   = render partial: 'shared/results_debug',
            locals: { es_request: @es_request_json,

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -67,3 +67,7 @@
   - if dl_item.repository_id == @selected_item.repository_id
     = hidden_field_tag('dl-download-item-index', index)
   = hidden_field_tag('dl-download-item-id', dl_item.repository_id)
+
+- unless defined?(@contact_form_rendered)
+  = render partial: 'layouts/contact_form'
+  - @contact_form_rendered = true 

--- a/app/views/items/show_collection_summary.html.haml
+++ b/app/views/items/show_collection_summary.html.haml
@@ -25,3 +25,7 @@
          locals: { context: :results,
                    num_downloadable_items: @num_downloadable_items,
                    total_byte_size: @total_byte_size }
+                   
+- unless defined?(@contact_form_rendered)
+  = render partial: 'layouts/contact_form'
+  - @contact_form_rendered = true 

--- a/app/views/items/show_directory.html.haml
+++ b/app/views/items/show_directory.html.haml
@@ -12,3 +12,7 @@
                                                 link_to_items: true }
 = render partial: 'staff_info', locals: { item: @item }
 = render partial: 'cite_panel', locals: { item: @item }
+
+- unless defined?(@contact_form_rendered)
+  = render partial: 'layouts/contact_form'
+  - @contact_form_rendered = true 

--- a/app/views/items/show_file.html.haml
+++ b/app/views/items/show_file.html.haml
@@ -67,3 +67,7 @@
       Email Curator About This File
 
 = render partial: 'cite_panel', locals: { item: @item }
+
+- unless defined?(@contact_form_rendered)
+  = render partial: 'layouts/contact_form'
+  - @contact_form_rendered = true 

--- a/app/views/items/show_restricted.html.haml
+++ b/app/views/items/show_restricted.html.haml
@@ -33,3 +33,7 @@
   %section= metadata_section(@item)
 
 = render partial: 'staff_info', locals: { item: @item }
+
+- unless defined?(@contact_form_rendered)
+  = render partial: 'layouts/contact_form'
+  - @contact_form_rendered = true 

--- a/app/views/layouts/_contact_form.html.haml
+++ b/app/views/layouts/_contact_form.html.haml
@@ -9,7 +9,7 @@
 
   .collapse#contact-form
     .alert#contact-form-alert{style: "display: none"}
-    = form_tag(contact_path, method: :post, remote: true, id: "contact-form") do
+    = form_tag(contact_path, method: :post, id: "contact-form") do
       -# see for an explanation of the force_encoding():
       -# https://github.com/rails/rails/issues/23978#issuecomment-290032710
       = hidden_field_tag(:page_url, request.url.force_encoding("UTF-8"))

--- a/app/views/layouts/_contact_form.html.haml
+++ b/app/views/layouts/_contact_form.html.haml
@@ -28,6 +28,6 @@
           .mb-3
             - captcha_hash = captcha 
             = captcha_hash[:label]
-            = captcha_hash[:field]
+            = captcha_hash[:field].gsub('id="answer"', 'id="contact-answer"').html_safe 
           .mb-3 
             = submit_tag("Submit", class: "btn btn-primary", id: "submit-button", disabled: true)

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -3,7 +3,9 @@
     .col-sm-12.text-line
       .contact-area
         The Digital Collections are a product of the University Library.
-        = render partial: "layouts/contact_form"
+        - unless defined?(@contact_form_rendered)
+          = render partial: "layouts/contact_form"
+          - @contact_form_rendered = true 
     
   %il-footer{role: "contentinfo"}
     .il-footer-contact.uofi_address{slot: "contact", style: "text-align: left;"}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,8 +18,8 @@ Rails.application.routes.draw do
     match '/stream', to: 'binaries#stream', via: :get
   end
 
-  match '/contact', to: 'landing#contact', via: :post,
-        constraints: lambda { |request| request.xhr? }
+  match '/contact', to: 'landing#contact', via: :post
+        # constraints: lambda { |request| request.xhr? }
 
   match '/collections/iiif', to: 'collections#iiif_presentation_list',
         via: :get, as: 'collections_iiif_presentation_list',


### PR DESCRIPTION
This PR addresses [Issue 118](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=71123614&issue=medusa-project%7Cdigital-library-issues%7C118) 

### **Summary of Changes:**

- Removes AJAX constraint for `POST /contact`
- Resets the form fields upon submission
- Returns a notice for successful submission AND for error
- Redirects user back to current path they submit the form from
- Sets a flag inside `_footer partial`, `_items partial `and various `items-show views` to prevent contact form from being rendered twice, no matter where in the application it's being referenced.
- Updates the `kumquat.js `and `items.js` JS files with contact form functionality, modifying `items.js` that encapsulates the part of kumquat responsible for the items-show pages.
- Modifies the `captcha field ID `to be unique (`contact-answer vs answer`) because there are different captchas being used for downloading items.

### Screen recording showing how the contact us form works on every endpoint:


https://github.com/user-attachments/assets/6e4b0c15-a101-4ea1-a22f-1ac848753e6e


