### PR TITLE
Feature 139 - Zip Download upgrades

### DIFF
--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -109,37 +109,17 @@ const Application = {
     AJAXShade: function() {
 
         var shade = $('#dl-ajax-shade');
-        // http://spin.js.org
-        var spinner = new Spinner({
-            lines: 13 // The number of lines to draw
-            , length: 28 // The length of each line
-            , width: 14 // The line thickness
-            , radius: 42 // The radius of the inner circle
-            , scale: 1 // Scales overall size of the spinner
-            , corners: 1 // Corner roundness (0..1)
-            , color: '#fff' // #rgb or #rrggbb or array of colors
-            , opacity: 0.25 // Opacity of the lines
-            , rotate: 0 // The rotation offset
-            , direction: 1 // 1: clockwise, -1: counterclockwise
-            , speed: 1 // Rounds per second
-            , trail: 60 // Afterglow percentage
-            , fps: 20 // Frames per second when using setTimeout() as a fallback for CSS
-            , zIndex: 2e9 // The z-index (defaults to 2000000000)
-            , className: 'spinner' // The CSS class to assign to the spinner
-            , top: '50%' // Top position relative to parent
-            , left: '50%' // Left position relative to parent
-            , shadow: false // Whether to render a shadow
-            , hwaccel: false // Whether to use hardware acceleration
-            , position: 'absolute' // Element positioning
-        });
+        var progressBar = $('<div class="progress-bar progress-bar-striped progress-bar-animated bg-info" role="progressbar" style="width: 100%; height: 2em;"></div>');
+        var progressContainer = $('<div class="progress" style="height: 2em;"></div>').append(progressBar);
 
         this.hide = function() {
-            spinner.stop();
+            progressContainer.hide();
             shade.hide();
         };
 
         this.show = function() {
-            spinner.spin(shade[0]);
+            shade.append(progressContainer);
+            progressContainer.show();
             shade.show();
         };
 
@@ -168,10 +148,10 @@ const Application = {
                     form.remove();
                     modalBody.html(waitMessageHTML +
                         '<div class="text-center">' +
-                            '<div class="spinner-border" role="status">' +
-                                '<span class="sr-only">Loading&hellip;</span>' +
+                            '<div class="progress-bar progress-bar-striped progres-bar-animated bg-info" ' + 'role="progressbar" style="width: 100%; height: 2em;"></div>' +
                             '</div>' +
                         '</div>');
+                    
 
                     // Poll the Download representation at an interval, updating
                     // the modal content (e.g. progress bar) at each refresh.

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -148,7 +148,8 @@ const Application = {
                     form.remove();
                     modalBody.html(waitMessageHTML +
                         '<div class="text-center">' +
-                            '<div class="progress-bar progress-bar-striped progres-bar-animated bg-info" ' + 'role="progressbar" style="width: 100%; height: 2em;"></div>' +
+                            '<div class="progress-bar progress-bar-striped progres-bar-animated bg-info" ' + 
+                              'role="progressbar" style="width: 100%; height: 2em;"></div>' +
                             '</div>' +
                         '</div>');
                     

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -314,9 +314,9 @@ class ItemsController < WebsiteController
         # so the strategy is to do it using the asynchronous download feature.
         item_ids = download_relation.to_a.map(&:repository_id)
         if item_ids.any?
-          start    = params[:download_start].to_i + 1
-          end_     = params[:download_start].to_i + item_ids.length
-          zip_name = "items-#{start}-#{end_}"
+          start    = params[:download_start].to_i 
+          end_     = params[:download_start].to_i + item_ids.length - 1
+          zip_name = "items-#{start + 1}-#{end_ + 1}"
           download = Download.create(ip_address: request.remote_ip)
           DownloadZipJob.perform_later(item_ids:                 item_ids,
                                        zip_name:                 zip_name,

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -281,6 +281,14 @@ class ItemsController < WebsiteController
     @num_downloadable_items = download_relation.count
     @total_byte_size        = download_relation.total_byte_size
 
+    # create instance of medusa downloader client
+    # retrieve targets_for to get zip download data and assign to @targets instance variable
+    # call on private extract method on @targets to extract the file names of the zip download so we can call on this inside the view
+    # 
+    medusa_downloader       = MedusaDownloaderClient.new
+    @targets                = medusa_downloader.process_targets(@items)
+    @file_names             = extract_file_names(@targets)
+
     respond_to do |format|
       format.html do
         session[:first_result_id] = @items.first&.repository_id
@@ -737,4 +745,8 @@ class ItemsController < WebsiteController
     @permitted_params = params.permit(PERMITTED_SEARCH_PARAMS)
   end
 
+  # private method to extract the file_names in the zip download
+  def extract_file_names(targets)
+    targets.map{|target| File.basename(target[:path])}.uniq
+  end
 end

--- a/app/medusa/medusa_downloader_client.rb
+++ b/app/medusa/medusa_downloader_client.rb
@@ -82,6 +82,10 @@ class MedusaDownloaderClient
     raise IOError, response.status if response.status != 200
   end
 
+  # helper method that is public calls on targets_for pvt method so ItemsController can have access to the method
+  def process_targets(items, include_private_binaries: false)
+    targets_for(items, include_private_binaries: include_private_binaries)
+  end
 
   private
 

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -67,22 +67,15 @@
                 = mail_to 'digitalcollections@lists.illinois.edu', 'Digital Library Team' 
                 for more options. 
           .tab-content
-            #dl-download-batches.tab-pane.fade.show{role:              "tabpanel",
-                                                    "aria-labelledby": "dl-download-batches-tab"}
+            #dl-download-batches.tab-pane.fade.show{role: "tabpanel", "aria-labelledby": "dl-download-batches-tab"}
               - if total_byte_size > 0
                 %p.form-text.text-muted.text-center
                   Estimated average file size: #{number_to_human_size(batch_byte_size)}
               = download_captcha(@permitted_params.except(:start).merge(format: :zip)) do
                 = hidden_field_tag("limit", batch_size)
-                - num_batches.times do |i|
-                  .form-check
-                    = radio_button_tag(:download_start, i * batch_size,
-                                       class: "form-check-input",
-                                       type:  "radio")
-                    = label_tag("download_start_#{i * batch_size}",
-                                "Batch #{i + 1}",
-                                class: "form-check-label mb-1")
-
+                - options = num_batches.times.map { |i| ["Batch #{i + 1}", i * batch_size] }
+                .form-group
+                  = select_tag :download_start, options_for_select(options), class: "form-control"
             #dl-download-one.tab-pane.fade.show{role:              "tabpanel",
                                                 "aria-labelledby": "dl-download-one-tab"}
               - if total_byte_size < download_size_limit

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -3,6 +3,8 @@
 -# context [Symbol] :directory, :item, or :results
 -# num_downloadable_items [Integer]
 -# total_byte_size [Integer]
+-# file_names [Array]
+
 - download_size_limit = Rails.application.credentials.download_size_limit.to_f 
 
 - if total_byte_size > 0
@@ -75,7 +77,9 @@
                 = hidden_field_tag("limit", batch_size)
                 - start = num_batches.times.map { |i| i * batch_size }
                 - end_ = num_batches.times.map { |i| (i + 1) * batch_size - 1 }
-                - options = num_batches.times.map { |i| ["Batch #{i + 1} - items #{start[i] + 1} to #{end_[i] + 1}", start[i]] }
+                - options = num_batches.times.map do |i|
+                  - batch_file_names = @file_names[start[i]..end_[i]]&.join(', ') || 'Unknown files'
+                  - ["Batch #{i + 1} - items #{start[i] + 1} to #{end_[i] + 1} - Files: (#{batch_file_names})", start[i]]
                 .form-group
                   = select_tag :download_start, options_for_select(options), class: "form-control"
             #dl-download-one.tab-pane.fade.show{role:              "tabpanel",

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -64,10 +64,14 @@
               %p.form-text.text-muted.text-center
                 Due to large file size, these items are only available in multiple batch downloads.         
               %p.form-text.text-muted.text-center
-                If you know which items you need to download, please download the item directly from the item's page.        
-                If you need all items at once contact the 
-                = mail_to 'digitalcollections@lists.illinois.edu', 'Digital Library Team' 
-                for more options. 
+                If you know which items you need to download, please download the item directly from the item's page.
+              %p.form-text.text-muted.text-centered
+              .alert.alert-light
+                %p{ style: "color: #ff5733; text-align: center;" }
+                  = icon_for(:info)
+                  If you need all items in a single download, please close 
+                  this window and send us a message using the
+                  Contact us form at the bottom of the page.
           .tab-content
             #dl-download-batches.tab-pane.fade.show{role: "tabpanel", "aria-labelledby": "dl-download-batches-tab"}
               - if total_byte_size > 0

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -78,7 +78,10 @@
                 - start = num_batches.times.map { |i| i * batch_size }
                 - end_ = num_batches.times.map { |i| (i + 1) * batch_size - 1 }
                 - options = num_batches.times.map do |i|
-                  - batch_file_names = @file_names[start[i]..end_[i]]&.join(', ') || 'Unknown files'
+                  - if @file_names && @file_names[start[i]..end_[i]]
+                    - batch_file_names = @file_names[start[i]..end_[i]].uniq.join(', ')
+                  - else 
+                    - batch_file_names = 'Unknown files'
                   - ["Batch #{i + 1} - items #{start[i] + 1} to #{end_[i] + 1} - Files: (#{batch_file_names})", start[i]]
                 .form-group
                   = select_tag :download_start, options_for_select(options), class: "form-control"

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -73,9 +73,9 @@
                   Estimated average file size: #{number_to_human_size(batch_byte_size)}
               = download_captcha(@permitted_params.except(:start).merge(format: :zip)) do
                 = hidden_field_tag("limit", batch_size)
-                - start = num_batches.times.map { |i| i * batch_size + 1 }
-                - end_ = num_batches.times.map { |i| (i + 1) * batch_size }
-                - options = num_batches.times.map { |i| ["Batch #{i + 1} - items #{start[i]} to #{end_[i]}", start[i]] }
+                - start = num_batches.times.map { |i| i * batch_size }
+                - end_ = num_batches.times.map { |i| (i + 1) * batch_size - 1 }
+                - options = num_batches.times.map { |i| ["Batch #{i + 1} - items #{start[i] + 1} to #{end_[i] + 1}", start[i]] }
                 .form-group
                   = select_tag :download_start, options_for_select(options), class: "form-control"
             #dl-download-one.tab-pane.fade.show{role:              "tabpanel",

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -73,7 +73,9 @@
                   Estimated average file size: #{number_to_human_size(batch_byte_size)}
               = download_captcha(@permitted_params.except(:start).merge(format: :zip)) do
                 = hidden_field_tag("limit", batch_size)
-                - options = num_batches.times.map { |i| ["Batch #{i + 1}", i * batch_size] }
+                - start = num_batches.times.map { |i| i * batch_size + 1 }
+                - end_ = num_batches.times.map { |i| (i + 1) * batch_size }
+                - options = num_batches.times.map { |i| ["Batch #{i + 1} - items #{start[i]} to #{end_[i]}", start[i]] }
                 .form-group
                   = select_tag :download_start, options_for_select(options), class: "form-control"
             #dl-download-one.tab-pane.fade.show{role:              "tabpanel",

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -75,14 +75,16 @@
                   Estimated average file size: #{number_to_human_size(batch_byte_size)}
               = download_captcha(@permitted_params.except(:start).merge(format: :zip)) do
                 = hidden_field_tag("limit", batch_size)
-                - start = num_batches.times.map { |i| i * batch_size }
-                - end_ = num_batches.times.map { |i| (i + 1) * batch_size - 1 }
-                - options = num_batches.times.map do |i|
-                  - if @file_names && @file_names[start[i]..end_[i]]
-                    - batch_file_names = @file_names[start[i]..end_[i]].uniq.join(', ')
-                  - else 
-                    - batch_file_names = 'Unknown files'
-                  - ["Batch #{i + 1} - items #{start[i] + 1} to #{end_[i] + 1} - Files: (#{batch_file_names})", start[i]]
+                - options = []
+                - if @file_names && !@file_names.empty?
+                  - start = num_batches.times.map { |i| i * batch_size }.select { |i| i < @file_names.size }
+                  - end_ = start.map { |i| [i + batch_size - 1, @file_names.size - 1].min }
+                  - options = start.each_with_index.map do |s, i|
+                    - if @file_names[s..end_[i]]
+                      - batch_file_names = @file_names[s..end_[i]].uniq.join(', ')
+                    - else 
+                      - batch_file_names = 'No Files'
+                    - ["Batch #{i + 1} - items #{s + 1} to #{end_[i] + 1} - Files: (#{batch_file_names})", s]
                 .form-group
                   = select_tag :download_start, options_for_select(options), class: "form-control"
             #dl-download-one.tab-pane.fade.show{role:              "tabpanel",

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -59,4 +59,5 @@
   = render partial: 'download_zip_panel',
            locals: { context: :results,
                      num_downloadable_items: @num_downloadable_items,
-                     total_byte_size: @total_byte_size }
+                     total_byte_size: @total_byte_size,
+                     file_names: @file_names }


### PR DESCRIPTION
[Issue 139](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=95573636&issue=medusa-project%7Cdigital-library-issues%7C139) (and several sub-issues related). 

### Sub-issues Addressed:

- [x] List which items are in a download batch 
- [x] Change the download spinner to a progress bar
- [x] Change radio button form to select menu form
- [x] List which files are in each batch 
- [ ] Redundant 'download items in batches' button removed
- [ ] Download Zip file should reset after download file is prepared
- [x] Captcha answer should reset on page load
- [x] Confirm compound objects should be available in batch downloads
- [x] Skipping to one of higher batches listed causes web page to hang indefinitely
- [x] Null error on large book after selecting a batch to download

### Summary of Changes:
- radio buttons in `_download_zip_panel` partial changed to select options menu:

  - options set to an empty array 
  - inside `ItemsController` a new instance of the `MedusaDownloaderClient` is instantiated
  - this new instance of `medusa_downloader` calls on the `process_targets()` method to retrieve the `targets_for` zip download data
  - private method `extract_file_names()` takes in the `targets` retrieved from above to extract the exact file names in the zip download (this is saved to `file_names`)
  -  the zip download partial first checks that the `file_names` array exists and is not empty
  - the number of batches is iterated over to obtain staring indices (`start`)
  - the starting indices are iterated over to obtain the ending indices (`end_`), making sure it doesn't exceed the number of files
  - the starting indices are iterated over with index to extract the `file_names` 
  - these are assigned as the `batch_file_names` and string interpolated to show `Batch {n} - items {n} to {n} - files: {batch_file_names}`
  - this information is all fed into the `options` array from earlier
  - `options` included as an argument inside the form's `option_for_select` menu so each batch displays the items and files available

- download spinner in `kumquat.js` replaced with progress bar
- digital library email list replaced with an alert to utilize the `contact us` form at the bottom of the page

### Screenshots:
<img width="482" alt="Screenshot 2025-03-14 at 10 31 41 AM" src="https://github.com/user-attachments/assets/3b408630-1dee-4587-9d76-2301707df9de" />

<img width="843" alt="Screenshot 2025-03-14 at 10 34 23 AM" src="https://github.com/user-attachments/assets/159a02b7-16a6-4a57-a53e-19203220ca4e" />

<img width="616" alt="Screenshot 2025-03-14 at 10 40 42 AM" src="https://github.com/user-attachments/assets/e82eec03-8651-4263-ab80-7e692676de7f" />



