### PR TITLE
Feature 139 - changes to batch download selection menu

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -513,7 +513,7 @@ class ItemsController < WebsiteController
               include_restricted(false).
               host_groups(client_host_groups).
               to_a
-          items += [item] if @item.parent
+          items += [item] if !items.include?(item)
           zip_name = 'item'
         end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -281,14 +281,7 @@ class ItemsController < WebsiteController
     @num_downloadable_items = download_relation.count
     @total_byte_size        = download_relation.total_byte_size
 
-    # create instance of medusa downloader client
-    # retrieve targets_for to get zip download data and assign to @targets instance variable
-    # call on private extract method on @targets to extract the file names of the zip download so we can call on this inside the view
-    # 
-    medusa_downloader       = MedusaDownloaderClient.new
-    @targets                = medusa_downloader.process_targets(@items)
-    @file_names             = extract_file_names(@targets)
-
+    
     respond_to do |format|
       format.html do
         session[:first_result_id] = @items.first&.repository_id
@@ -745,8 +738,4 @@ class ItemsController < WebsiteController
     @permitted_params = params.permit(PERMITTED_SEARCH_PARAMS)
   end
 
-  # private method to extract the file_names in the zip download
-  def extract_file_names(targets)
-    targets.map{|target| File.basename(target[:path])}.uniq
-  end
 end

--- a/app/views/items/_download_section.html.haml
+++ b/app/views/items/_download_section.html.haml
@@ -51,7 +51,7 @@
 -# num_downloadable_items is potentially expensive to calculate.
 = render partial: 'download_zip_panel',
          locals: { context: item.directory? ? :directory : :item,
-                   num_downloadable_items: 0,
+                   num_downloadable_items: @downloadable_items.length,
                    total_byte_size: @total_byte_size }
 = render partial: 'download_zip_of_jpegs_panel', locals: { item: item }
 = render partial: 'download_pdf_panel', locals: { item: item }

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -84,7 +84,7 @@
                   - end_indices = start_indices.map { |i| [i + batch_size - 1, num_downloadable_items - 1].min }
                   - options = start_indices.each_with_index.map do |start_idx, i|
                     - end_idx = end_indices[i]
-                    - ["Batch #{i + 1} - items #{start_idx + 1} to #{end_idx + 1}", start_idx]
+                    - ["Batch #{i + 1}: items #{start_idx + 1} - #{end_idx + 1} (Contains #{end_idx - start_idx + 1} item(s))", start_idx]
                 .form-group
                   = select_tag :download_start, options_for_select(options), class: "form-control"
             #dl-download-one.tab-pane.fade.show{role:              "tabpanel",

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -80,15 +80,12 @@
               = download_captcha(@permitted_params.except(:start).merge(format: :zip)) do
                 = hidden_field_tag("limit", batch_size)
                 - options = []
-                - if @file_names && !@file_names.empty?
-                  - start = num_batches.times.map { |i| i * batch_size }.select { |i| i < @file_names.size }
-                  - end_ = start.map { |i| [i + batch_size - 1, @file_names.size - 1].min }
-                  - options = start.each_with_index.map do |s, i|
-                    - if @file_names[s..end_[i]]
-                      - batch_file_names = @file_names[s..end_[i]].uniq.join(', ')
-                    - else 
-                      - batch_file_names = 'No Files'
-                    - ["Batch #{i + 1} - items #{s + 1} to #{end_[i] + 1} - Files: (#{batch_file_names})", s]
+                - if num_downloadable_items > 0
+                  - start_indices = num_batches.times.map { |i| i * batch_size }.select { |i| i < num_downloadable_items }
+                  - end_indices = start_indices.map { |i| [i + batch_size - 1, num_downloadable_items - 1].min }
+                  - options = start_indices.each_with_index.map do |start_idx, i|
+                    - end_idx = end_indices[i]
+                    - ["Batch #{i + 1} - items #{start_idx + 1} to #{end_idx + 1}", start_idx]
                 .form-group
                   = select_tag :download_start, options_for_select(options), class: "form-control"
             #dl-download-one.tab-pane.fade.show{role:              "tabpanel",
@@ -97,6 +94,7 @@
                 %p.form-text.text-muted.text-center
                   Estimated file size: #{number_to_human_size(total_byte_size)}
                 = download_captcha(@permitted_params.except(:start).merge(format: :zip, download_start: 0, limit: 0))
+
 
 
         - else

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -3,7 +3,6 @@
 -# context [Symbol] :directory, :item, or :results
 -# num_downloadable_items [Integer]
 -# total_byte_size [Integer]
--# file_names [Array]
 
 - download_size_limit = Rails.application.credentials.download_size_limit.to_f 
 

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -59,5 +59,4 @@
   = render partial: 'download_zip_panel',
            locals: { context: :results,
                      num_downloadable_items: @num_downloadable_items,
-                     total_byte_size: @total_byte_size,
-                     file_names: @file_names }
+                     total_byte_size: @total_byte_size }


### PR DESCRIPTION
### Summary of Changes:
- Replaces `file_names` array with `num_downloadable_items` thereby removing file names to free up space in the menu, and ensuring batching logic accounts for all available downloadable items in the collection.
   - inside the view, `file_names.size` was limiting the batches based on only the files from the current page rather than all downloadable items, using this filter: `.select { |i| i < @file_names.size }`
  
    Example:
  
       - Items Controller performs a search on 1000 total items, but only 20 items are displayed on the current page. 
       - The logic in the view calculates 50 batches based on the total byte size. 
       - The dropdown would only show batches for the 20 items on the current page, not ALL 1000 items

- For particularly large collections (2 TB+), trying to include all the filenames in the dropdown might have caused strain leading to incomplete/empty lists.
- Now shows each batch, along with range of items and total number of items per batch (see screenshot)
- Updates the `Items#show` action so that compound objects can also be downloaded as batches (removes the conditional that the item must be a parent to be included)
- Adds the `number of downloadable items` in the `_download_section` partial for `item-show` pages

## Screenshots:

- Example of Batch Menu Selection on items index page:
<img width="358" alt="Screenshot 2025-03-20 at 11 49 38 AM" src="https://github.com/user-attachments/assets/1f2b6a96-db47-43fa-891b-8de8e97bc732" />

- Example of Batch Menu Selection within the Download Section of an item show page:
<img width="885" alt="Screenshot 2025-03-20 at 3 34 55 PM" src="https://github.com/user-attachments/assets/25f3a25b-596b-41fd-9875-b9be1997251f" />


