### PR TITLE
Zip Download - Resets modal content after each download

### DIFF
--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -145,9 +145,11 @@ const Application = {
             success: function (data, status, xhr) {
               const waitMessageHTML = `
                 <p>Your file is being prepared. When it's ready, a download button will appear below.</p>
-                  <div class="progress-bar progress-bar-striped progres-bar-animated bg-info"
-                    <role="progressbar" style="width: 100%; height: 2em;">
+                  <div class="text-center">
+                    <div class="progress-bar progress-bar-striped progres-bar-animated bg-info"
+                      <role="progressbar" style="width: 100%; height: 2em;">
                   </div>
+                </div>
                 `;
 
                 modalBody.html(waitMessageHTML);

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -127,6 +127,8 @@ const Application = {
 
     CaptchaProtectedDownload: function() {
         const forms = $(".dl-captcha-form");
+        // add const that will restore the dl-download-zip modal to its original content
+        const originalModalContent = $('#dl-download-zip-modal .modal-body').html();
         forms.on("submit", function(e) {
             e.preventDefault();
             const form = $(e.target);
@@ -209,7 +211,11 @@ const Application = {
                         "<div class='alert alert-danger'>" + message + "</div>");
                 }
             });
-        })
+        });
+        // Add event listener so the download zip modal is reset when closed
+        $('#dl-download-zip-modal').on('hidden.bs.modal', function() {
+          $(this).find(".modal-body").html(originalModalContent);
+        });
     },
 
     /**

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -134,6 +134,25 @@ const Application = {
           const form = $(e.target);
           form.find(".alert").remove();
 
+          let url = form.attr("action").include("?")
+            ? form.attr('action') + "&" + form.serialize()
+            : form.attr('action') + "?" + form.serialize();
+
+          $.ajax({
+            url: url,
+            method: 'GET',
+            dataType: 'script',
+            success: function (data, status, xhr) {
+              const waitMessageHTML = `
+                <p>Your file is being prepared. When it's ready, a download button will appear below.</p>
+                  <div class="progress-bar progress-bar-striped progres-bar-animated bg-info"
+                    <role="progressbar" style="width: 100%; height: 2em;">
+                  </div>
+                `;
+
+                modalBody.html(waitMessageHTML);
+            }
+          })
         
         }
       },

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -177,7 +177,7 @@ const Application = {
           dataType: 'json',
           success: function (data, status, xhr) {
             let href = data.filename ? `/downloads/${data.key}/file` : data.url;
-            let pct = data.task.total > 0 ? Math.round(100 * data.task.current / data.task.total) : 0;
+            // let pct = data.task.total > 0 ? Math.round(100 * data.task.current / data.task.total) : 0;
 
             if (parseInt(data.task.status) === 4) {
               modalBody.html("<p>There was an error preparing the file.</p>");
@@ -197,12 +197,10 @@ const Application = {
                 <p>Your file is being prepared. Please wait...</p>
                 <div class="progress">
                   <div class="progress-bar progress-bar-striped progress-bar-animated bg-info"
-                    role="progressbar" style="width: ${pct}%;">
+                    role="progressbar" style="width: 100%;">
                   </div>
-                </div>
-                <p class="text-center">${pct}%</p>`
-                  
-              );
+                </div>  
+              `);
             }
           },
           error: function() {

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -126,97 +126,19 @@ const Application = {
     },
 
     CaptchaProtectedDownload: function() {
-        const forms = $(".dl-captcha-form");
-        // add const that will restore the dl-download-zip modal to its original content
-        const originalModalContent = $('#dl-download-zip-modal .modal-body').html();
-        forms.on("submit", function(e) {
-            e.preventDefault();
-            const form = $(e.target);
-            form.find(".alert").remove();
-            let url;
-            if (form.attr("action").includes("?")) {
-                url = form.attr('action') + "&" + form.serialize();
-            } else {
-                url = form.attr('action') + "?" + form.serialize();
-            }
-            $.ajax({
-                url:      url,
-                method:   'GET',
-                dataType: 'script',
-                success:  function(data, status, xhr) {
-                    const waitMessageHTML = '<p>Your file is being prepared. ' +
-                        'When it\'s ready, a download button will appear below.</p>';
-                    const modalBody = form.parents(".modal-body");
-                    form.remove();
-                    modalBody.html(waitMessageHTML +
-                        '<div class="text-center">' +
-                            '<div class="progress-bar progress-bar-striped progres-bar-animated bg-info" ' + 
-                              'role="progressbar" style="width: 100%; height: 2em;"></div>' +
-                            '</div>' +
-                        '</div>');
-                    
+        const modal = $("#dl-download-zip-modal");
+        const modalBody = modal.find(".modal-body");
+        const originalModalContent = modalBody.html();
+        function handleFormSubmit(e) {
+          e.preventDefault();
+          const form = $(e.target);
+          form.find(".alert").remove();
 
-                    // Poll the Download representation at an interval, updating
-                    // the modal content (e.g. progress bar) at each refresh.
-                    const intervalID = setInterval(function() {
-                        $.ajax({
-                            url:      xhr.getResponseHeader("X-Kumquat-Location"),
-                            method:   'GET',
-                            dataType: 'json',
-                            success:  function(data, status, xhr) {
-                                var href = null;
-                                if (data.filename) {
-                                    href = "/downloads/" + data.key + "/file";
-                                } else if (data.url) {
-                                    href = data.url;
-                                }
-                                if (parseInt(data.task.status) === 4) { // failed
-                                    modalBody.html("<p>There was an error preparing the file.</p>");
-                                    clearInterval(intervalID);
-                                } else if (href) {
-                                    modalBody.html('<div class="text-center">' +
-                                            '<a href="' + href + '" class="btn btn-lg btn-success">' +
-                                                '<i class="fa fa-download"></i> Download' +
-                                            '</a>' +
-                                        '</div>');
-                                    clearInterval(intervalID);
-                                } else if (!data.task.indeterminate) {
-                                    const pct = Math.round(data.task.percent_complete * 100);
-                                    modalBody.html(waitMessageHTML +
-                                        '<div class="progress mt-3" style="height: 2em">' +
-                                            '<div class="progress-bar progress-bar-striped progress-bar-animated bg-info" ' +
-                                                'aria-valuemax="100" ' +
-                                                'aria-valuemin="0" ' +
-                                                'aria-valuenow="' + pct + '" ' +
-                                                'role="progressbar" ' +
-                                                'style="width:' + pct + '%">' +
-                                            '</div>' +
-                                        '</div>' +
-                                        '<span class="sr-only">' + pct + '% complete</span>' +
-                                        '<p class="text-center">' + pct + '%</p>');
-                                }
-                            },
-                            error: function(request, status, error) {
-                                clearInterval(intervalID);
-                                const message = request.getResponseHeader('X-Kumquat-Message');
-                                modalBody.append(
-                                    "<div class='alert alert-danger'>" + message + "</div>");
-                            }
-                        });
-                    }, 5000);
-                },
-                error: function(request, status, error) {
-                    const message = request.getResponseHeader('X-Kumquat-Message');
-                    form.prepend(
-                        "<div class='alert alert-danger'>" + message + "</div>");
-                }
-            });
-        });
-        // Add event listener so the download zip modal is reset when closed
-        $('#dl-download-zip-modal').on('hidden.bs.modal', function() {
-          $(this).find(".modal-body").html(originalModalContent);
-        });
-    },
+        
+        }
+      },
+
+                   
 
     /**
      * Marks changed form fields as dirty.

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -151,6 +151,18 @@ const Application = {
                 `;
 
                 modalBody.html(waitMessageHTML);
+
+                const pollingUrl = xhr.getResponseHeader("X-Kumquat-Location");
+                if (!pollingUrl) {
+                  modalBody.append("<p class='text-danger'>Error: No polling URL found.</p>");
+                  return
+                }
+
+                startPolling(pollingUrl);
+            },
+            error: function(request, status, error) {
+              const message = request.getResponseHeader('X-Kumquat-Message') || "An error occurred.";
+              form.prepend(`<div class='alert alert-danger'>${message}</div`);
             }
           })
         

--- a/app/assets/javascripts/kumquat.js
+++ b/app/assets/javascripts/kumquat.js
@@ -213,6 +213,9 @@ const Application = {
       }, 5000);
     }
 
+  // Note: This doesn't allow for parallel downloads. 
+  // The user will have to wait for the first download batch to finish before starting again. 
+  // Might want to refactor this at some point.
     function resetModal() {
       modalBody.html(originalModalContent);
       modal.find(".dl-captcha-form").off("submit", handleFormSubmit).on("submit", handleFormSubmit);

--- a/app/views/items/_download_zip_panel.html.haml
+++ b/app/views/items/_download_zip_panel.html.haml
@@ -43,7 +43,7 @@
             = icon_for(:info)
             Zip files include all files in the current folder tree.
 
-        - if num_batches > 1
+        - if num_batches > 0
           .alert.alert-light 
             = icon_for(:info)
             Estimated file size: #{number_to_human_size(total_byte_size)}


### PR DESCRIPTION
This addresses the bug from issue [139 ](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=95573636&issue=medusa-project%7Cdigital-library-issues%7C139)- sub-issue [150](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=2876400208&issue=medusa-project%7Cdigital-library-issues%7C150): 

_After downloading a batch, clicking on Download Zip presents the same exact file download_

### Summary of Changes:

  - store references to `dl-download-zip modal body` and store the `original modal content`
  - refactor how the form submission and download progress message
  - sets a `pollingUrl` constant equal to the response headers to `check file's status` and adds an error message if no url is found
  - `startPolling` calls on pollingUrl for `server updates` checking file download
  - adds `function to reset the modal on close` to original content
  - `handleFormSubmit` binds to the captcha form so it's in a fresh state each time it's opened

### Screencasts:

##### /collections/{:collection_id}/items 


https://github.com/user-attachments/assets/9f693852-4a78-4c23-98a4-f141f36e66bf

##### /items/{:item_id}

https://github.com/user-attachments/assets/54253cf7-c5e8-424f-a240-41f94e6c726b









