### PR TITLE
Admin search for sub-collections with the filter field 

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -80,6 +80,7 @@ module Admin
           query_all(params[:q]).
           include_unpublished(true).
           include_restricted(true).
+          search_children(true).
           order(CollectionElement.new(name: 'title').indexed_sort_field).
           start(@start).
           limit(@limit)

--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -93,7 +93,7 @@ module Admin
       end
 
       @collections  = relation.to_a
-      @current_page = (@start / @limit.to_f).ceil + 1 if @limit > 0 || 1
+      @current_page = (@start / @limit.to_f).ceil + 1 if @limit > 0 || @limit == 1
       @count        = relation.count
 
       respond_to do |format|


### PR DESCRIPTION
Issue [140](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=97476145&issue=medusa-project%7Cdigital-library-issues%7C140): 

> DLS admins assumed we could use the filter field in the collections list to find the sub-collection noted above. There is not a syncing issue. We found the sub-collections in the Digital Library once we searched for the parent collection. We would like to search for sub-collections with the filter field, because we can't find them unless we know the parent collection

`controllers > admin > CollectionsController > index action`: 
- added `search_children(true)` to the chain inside the `relation` variable so sub-collections can now be searched without having to know the parent collection it's from.

Before this change:
<img width="1054" alt="Screenshot 2025-05-12 at 2 54 07 PM" src="https://github.com/user-attachments/assets/e3782a2c-825a-4b5f-be02-111b1dd7e188" />


After this change:
<img width="1042" alt="Screenshot 2025-05-12 at 2 45 22 PM" src="https://github.com/user-attachments/assets/0f9df44b-e336-4ae8-9aeb-f7d52ae17b93" />

