### PR TITLE
OCR Indicator - binary updates 

### DIFF
--- a/app/jobs/ocr_binary_job.rb
+++ b/app/jobs/ocr_binary_job.rb
@@ -25,6 +25,7 @@ class OcrBinaryJob < ApplicationJob
     self.task&.update(status_text: "Running OCR on #{binary.object_key}")
 
     binary.detect_text(language: args[:language_code])
+    binary.ocred_at = Time.current 
     binary.save!
     binary.item.reindex
     binary.item.update!(ocred: true)

--- a/app/jobs/ocr_collection_job.rb
+++ b/app/jobs/ocr_collection_job.rb
@@ -40,6 +40,7 @@ class OcrCollectionJob < ApplicationJob
                                     num_threads: num_threads,
                                     task: self.task) do |binary|
       binary.detect_text(language: args[:language_code])
+      binary.ocred_at = Time.current 
       binary.save!
       binary.item.reindex
     end

--- a/app/jobs/ocr_item_job.rb
+++ b/app/jobs/ocr_item_job.rb
@@ -53,6 +53,7 @@ class OcrItemJob < ApplicationJob # TODO: replace this with OcrItemsJob
                                     num_threads: num_threads,
                                     task: self.task) do |binary|
       binary.detect_text(language: args[:language_code])
+      binary.ocred_at = Time.current 
       binary.save!
       binary.item.reindex
     end

--- a/app/jobs/ocr_items_job.rb
+++ b/app/jobs/ocr_items_job.rb
@@ -39,6 +39,7 @@ class OcrItemsJob < ApplicationJob
                                     num_threads: num_threads,
                                     task: self.task) do |binary|
       binary.detect_text(language: args[:language_code])
+      binary.ocred_at = Time.current 
       binary.save!
       binary.item.reindex
     end

--- a/db/migrate/20250610194815_backfill_ocred_on_items_again.rb
+++ b/db/migrate/20250610194815_backfill_ocred_on_items_again.rb
@@ -1,0 +1,11 @@
+class BackfillOcredOnItemsAgain < ActiveRecord::Migration[7.1]
+  def up
+    # This migration is a workaround for the fact that some items were not
+    # marked as ocred when they should have been, due to a bug in the OCR jobs.
+    Item.find_each do |item|
+      if item.ocred_binaries.exists?
+        item.update_column(:ocred, true)
+      end
+    end
+  end
+end

--- a/db/migrate/20250610194815_backfill_ocred_on_items_again.rb
+++ b/db/migrate/20250610194815_backfill_ocred_on_items_again.rb
@@ -3,7 +3,7 @@ class BackfillOcredOnItemsAgain < ActiveRecord::Migration[7.1]
     # This migration is a workaround for the fact that some items were not
     # marked as ocred when they should have been, due to a bug in the OCR jobs.
     Item.find_each do |item|
-      if item.ocred_binaries.exists?
+      if item.ocred_binaries(recursive: true).exists?
         item.update_column(:ocred, true)
       end
     end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2025_06_03_174302) do
+ActiveRecord::Schema[7.1].define(version: 2025_06_10_194815) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"


### PR DESCRIPTION
Applies to [issue 154](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=110314775&issue=medusa-project%7Cdigital-library-issues%7C154)

### Problem

- Items that have already been OCRed (especially compound/parent items with binaries on child items) are not being recognized as OCRed in the UI.
- This is because the `ocred` flag on items is only set if at least one directly attached binary has a non-`nil` `ocred_at` timestamp.
- Binaries processed by older OCR jobs did not have their `ocred_at` field set, so even after a previous migration, these items are not marked as OCRed.

### Solution

- **OCR jobs have been updated** to set `binary.ocred_at = Time.current` after OCR is performed and before saving the binary. This ensures all newly OCRed binaries are properly timestamped.
- **A new backfill migration** (`BackfillOcredOnItemsAgain`) now checks all binaries for each item, including those on child items (`recursive: true`), and sets `ocred: true` on the item if any such binary has `ocred_at` set.
    ```ruby
    class BackfillOcredOnItemsAgain < ActiveRecord::Migration[7.1]
      def up
        # This migration is a workaround for the fact that some items were not
        # marked as ocred when they should have been, due to a bug in the OCR jobs.
        Item.find_each do |item|
          if item.ocred_binaries(recursive: true).exists?
            item.update_column(:ocred, true)
          end
        end
      end
    end
    ```

---

### N.B. (important caveat)

- **This migration will only mark items as OCRed if they (or their children) have at least one binary with a non-`nil` `ocred_at` timestamp.**
- If there are binaries that were OCRed before this fix and **do not** have `ocred_at` set, a bulk update or manual update needs to be made for those binaries to set `ocred_at` (e.g., `item.binaries.update_all(ocred_at: Time.current)`) **before running the migration**.
- Otherwise, those items will **not** be recognized as OCRed.
