### PR TITLE
tsv export with permalinks and some basic metadata for all objects in a collection

### DIFF
--- a/app/controllers/admin/collections_controller.rb
+++ b/app/controllers/admin/collections_controller.rb
@@ -67,6 +67,34 @@ module Admin
     end
 
     ##
+    # Responds to 
+    # `GET /admin/collections/:collection_id/export_permalinks_and_metadata`
+    #
+    def export_permalinks_and_metadata
+      authorize(@collection)
+      items = @collection.items
+
+      headers = ['Local ID', 'Collection Name', 'Object Title or Filename', 'Permalink'] # add any other
+      # headers you want to include in the TSV file here
+      tsv = StringIO.new
+      tsv << headers.join("\t") + "\n"
+      items.find_each do |item|
+        object_title = item.title.to_s.gsub(/\s+/, ' ').strip
+        local_id = item.id 
+        collection_name = @collection.title.to_s.gsub(/\s+/, ' ').strip
+        permalink = item_url(item, only_path: false)
+        tsv << [local_id, collection_name, object_title, permalink].join("\t") + "\n" # add any other
+        # metadata you want to include in the TSV file here based on the headers
+        # defined above
+      end
+
+      send_data tsv.string,
+                filename: "#{@collection.title.parameterize}-permalinks_and_metadata.tsv",
+                type:     'text/tab-separated-values'
+  
+    end
+
+    ##
     # Responds to `GET /admin/collections`
     #
     def index

--- a/app/policies/admin/collection_policy.rb
+++ b/app/policies/admin/collection_policy.rb
@@ -29,6 +29,10 @@ module Admin
       update?
     end
 
+    def export_permalinks_and_metadata?
+      show?
+    end
+
     def index?
       @user.medusa_user?
     end

--- a/app/views/admin/collections/show.html.haml
+++ b/app/views/admin/collections/show.html.haml
@@ -9,6 +9,11 @@
 = hidden_field_tag 'dl-collection-id', @collection.repository_id
 
 .btn-group.float-right{role: "group"}
+  -# Permalinks and Metadata button
+  = link_to export_permalinks_and_metadata_admin_collection_path(@collection),
+            class: 'btn btn-light' do
+    %i.fa.fa-download
+    Permalinks & Metadata TSV 
   -# Objects button
   = link_to admin_collection_items_path(@collection),
             class: 'btn btn-light' do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -97,6 +97,9 @@ Rails.application.routes.draw do
             constraints: lambda { |request| request.xhr? }
       match '/edit-representation', to: 'collections#edit_representation', via: :get,
             constraints: lambda { |request| request.xhr? }
+      member do 
+        get :export_permalinks_and_metadata
+      end
       resources :item_sets, except: :index do
         match '/all-items', to: 'item_sets#remove_all_items', via: :delete , as: "remove_all_items"
         match '/items', to: 'item_sets#items', via: :get, as: "items"

--- a/db/migrate/20250603174302_backfill_ocred_on_items.rb
+++ b/db/migrate/20250603174302_backfill_ocred_on_items.rb
@@ -1,9 +1,0 @@
-class BackfillOcredOnItems < ActiveRecord::Migration[7.1]
-  def up
-    Item.find_each do |item|
-      if item.ocred_binaries.exists?
-        item.update_column(:ocred, true)
-      end
-    end
-  end
-end


### PR DESCRIPTION
[Issue 157](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=111577945&issue=medusa-project%7Cdigital-library-issues%7C157)

### Summary of Changes:
- Adds a `member route` for item to export permalinks/metadata
- Grants permission to perform export inside `Admin Collection Policy`
- Updates UI on admin collection show page with `button to export` permalinks/metadata
- `Admin Collection Controller `action sets headers for requested fields (localID, collection title, object title, permalink) and creates a tsv export corresponding to the data fields

### Screenshots:
`Admin UI button:`
<img width="1239" alt="Screenshot 2025-06-23 at 10 05 15 AM" src="https://github.com/user-attachments/assets/ec22ee6e-940a-445d-9756-909123c71d89" />

`Admin UI download:`
<img width="1086" alt="Screenshot 2025-06-23 at 10 07 14 AM" src="https://github.com/user-attachments/assets/e12c1532-8da8-42cd-8844-b5b7c4ea7dff" />

`Sample tsv file:`
<img width="980" alt="Screenshot 2025-06-23 at 10 08 11 AM" src="https://github.com/user-attachments/assets/2088fa51-23c0-45c1-99c1-6e95701b07d3" />
