### PR TITLE
Feature 158/159: Ability to Search Across Subcollection Items

### DIFF
--- a/app/controllers/collections_controller.rb
+++ b/app/controllers/collections_controller.rb
@@ -60,6 +60,7 @@ class CollectionsController < WebsiteController
   # residing in them are NOT.
   #
   def show
+    @collection_ids = [@collection.repository_id] + @collection.children.pluck(:repository_id)
     @uofi_user = @collection.authorized_by_any_host_groups?(request_context.client_host_groups)
     respond_to do |format|
       format.html do

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -684,6 +684,7 @@ class ItemsController < WebsiteController
       sort = el.indexed_sort_field if el
     end
 
+    collection_ids = query[:collection_ids].presence || [query[:collection_id]].compact
     relation = Item.search.
         host_groups(client_host_groups).
         collection(@collection).
@@ -691,6 +692,11 @@ class ItemsController < WebsiteController
         order(sort).
         start(session[:start])
 
+    if collection_ids.present?
+      relation.collections(collection_ids)
+    elsif @collection
+      relation.collection(@collection)
+    end
     # Return results flattened if not viewing a file tree.
     if @collection&.free_form? && action_name != "tree_data"
       relation.search_children(true).

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -8,7 +8,7 @@ class ItemsController < WebsiteController
     SEARCHING           = 2
   end
 
-  PERMITTED_SEARCH_PARAMS = [:_, :collection_id, :df, :display, :download_start,
+  PERMITTED_SEARCH_PARAMS = [:_, :collection_id, { collection_ids: [] }, :df, :display, :download_start,
                              { fq: [] }, :field, :format, :id, :limit, :q,
                              :sort, :start]
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -234,6 +234,8 @@ class ItemsController < WebsiteController
   #
   def index
     authorize(Item)
+    collection_ids = params[:collection_ids] || [params[:collection_id]]
+    @items = Item.where(collection_repository_id: collection_ids)
     if !@collection && params[:q].blank?
       # We are not allowed to access /items without a query. /items is an
       # application-wide search endpoint, and we would prefer to direct users

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -217,6 +217,7 @@ module ApplicationHelper
       html <<     '<h4 class="dl-title">'
       html <<       link_to(entity.title, entity)
       html <<     '</h4>'
+      html <<       raw("#{entity.num_public_objects} Items")
       html <<   '</div>'
       html << '</div>'
     end

--- a/app/models/collection.rb
+++ b/app/models/collection.rb
@@ -751,6 +751,13 @@ harvestableByPrimo)
     nil
   end
 
+  ##
+  # @return [Integer] Total number of items across subcollections (parent collection's children collections)
+  #                   
+  def subcollections_public_items_count
+    children.sum(&:num_public_objects)
+  end
+
   def to_param
     self.repository_id
   end

--- a/app/search/item_relation.rb
+++ b/app/search/item_relation.rb
@@ -232,11 +232,16 @@ class ItemRelation < AbstractRelation
               end
             end
 
-            if @collection
+            if @collections
               j.child! do
+                j.terms do
+                  j.set! Item::IndexFields::COLLECTION, @collections
+                end
+              end
+            elsif @collection 
+              j.child! do 
                 j.term do
-                  j.set! Item::IndexFields::COLLECTION,
-                         @collection.repository_id
+                  j.set! Item::IndexFields::COLLECTION, @collection.repository_id
                 end
               end
             end

--- a/app/search/item_relation.rb
+++ b/app/search/item_relation.rb
@@ -29,6 +29,11 @@ class ItemRelation < AbstractRelation
     self
   end
 
+  def collections(ids)
+    @collections = ids
+    self
+  end
+
   ##
   # @param variants [String] One or more `Item::Variants` constant values.
   # @return [ItemRelation] The instance.

--- a/app/views/collections/_description.html.haml
+++ b/app/views/collections/_description.html.haml
@@ -5,6 +5,13 @@
                 class: 'btn btn-lg btn-outline-primary') do
         Browse Collection
         = icon_for(@collection)
+    - elsif @children.count > 0
+      -# If the collection has subcollections, link to subcollection section where 
+      -# users can see counts of items in subcollections and click on each card/entity.
+      = link_to '#subcollections', class: 'btn btn-lg btn-outline-primary' do 
+        = number_with_delimiter(@children.count)
+        = 'Subcollection'.pluralize(@children.count)
+        = icon_for(Item)
     - elsif @collection.published_in_dls 
       -# If the collection contains only one item, link straight to it.
       - if @num_public_objects == 1

--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -6,7 +6,10 @@
 %form.form-inline.float-right{action: "#{collection_items_path(@collection)}",
                               method: "get"}
   .input-group
-    - if @collection.published_in_dls && @uofi_user
+    - if @children.count > 1 || (@collection.published_in_dls && @uofi_user) 
+      -# Add hidden fields for collection_ids 
+      - @collection_ids.each do |id|
+        = hidden_field_tag 'collection_ids[]', id
       .input-group-prepend
         %span.input-group-text
           %i.fa.fa-search

--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -78,19 +78,9 @@
     Subcollections
     %small
       %span.badge.badge-pill.badge-secondary= @children.count
-    .row 
-    .col 
-      %div.mt-3.mb-3 
-        |
-        %span.text-muted
-          = 'Item'.pluralize(@collection.subcollections_public_items_count)
-        %small
-          %span.badge.badge-pill.badge-secondary
-            = number_with_delimiter(@collection.subcollections_public_items_count)
   .dl-cards-container.clearfix
     .dl-cards
       = entities_as_cards(@children)
-  
 
 .text-center.email-curator
   - mailto = curator_mailto(@collection)

--- a/app/views/collections/show.html.haml
+++ b/app/views/collections/show.html.haml
@@ -74,13 +74,23 @@
 
 - if @children.count > 0
   %hr/
-  %h2
+  %h2#subcollections 
     Subcollections
     %small
       %span.badge.badge-pill.badge-secondary= @children.count
+    .row 
+    .col 
+      %div.mt-3.mb-3 
+        |
+        %span.text-muted
+          = 'Item'.pluralize(@collection.subcollections_public_items_count)
+        %small
+          %span.badge.badge-pill.badge-secondary
+            = number_with_delimiter(@collection.subcollections_public_items_count)
   .dl-cards-container.clearfix
     .dl-cards
       = entities_as_cards(@children)
+  
 
 .text-center.email-curator
   - mailto = curator_mailto(@collection)

--- a/app/views/items/_items.html.haml
+++ b/app/views/items/_items.html.haml
@@ -4,7 +4,7 @@
     .col-md-auto
       = page_links
   .dl-cards.d-none.d-sm-block.d-md-none
-    = entities_as_cards(@items)
+    = entities_as_cards(@items. select {|i| i.is_a?(Collection)}) if @items.first.is_a?(Collection)
   .d-sm-none.d-md-block
     = entities_as_media(@items, show_collections: !@collection)
   .row.justify-content-md-center


### PR DESCRIPTION
Addresses Issues [158](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=111578591&issue=medusa-project%7Cdigital-library-issues%7C158) + [159](https://github.com/medusa-project/digital-library-issues/issues/159#issuecomment-3058272393): Improving collection page search functionality, supporting subcollection navigation and refining the item count display.

### Summary of Changes:
#### 1. Search Functionality:
- "Search this Collection" box now lets users search for items in both parent and child collections by passing relevant `collection_ids` as search params
- Updated logic in `ItemRelation > item_relation_for()` to support multiple collection search using OpenSearch `terms` filter when more than 1 collection is present
- Permits `collection_ids` as array of strong params at controller level

#### 2. Subcollection Navigation:
- If subcollections exist the button displays the number of subcollections and links to the subcollections section via anchor tag

#### 3. Item Count:
- Entity cards modified to display the correct number of items within each subcollection using `num_public_objects`

### Screenshots/Screencasts:

<img width="1324" height="795" alt="Screenshot 2025-07-15 at 10 08 20 AM" src="https://github.com/user-attachments/assets/6fc5d599-0883-4e34-93a9-0e872d4d659a" />


https://github.com/user-attachments/assets/77ae07e0-8f5f-42d7-91f2-db801015f130

