### PR TITLE
Bug 174: x_content_parse exception

### DIFF
--- a/app/search/item_relation.rb
+++ b/app/search/item_relation.rb
@@ -163,6 +163,7 @@ class ItemRelation < AbstractRelation
   # @return [String] JSON string.
   #
   def build_query
+    collections_array = @collections ? Array(@collections).flatten.compact : nil
     Jbuilder.encode do |j|
       j.track_total_hits true
       j.query do
@@ -232,14 +233,14 @@ class ItemRelation < AbstractRelation
               end
             end
 
-            if @collections
-              j.child! do
+            if collections_array && collections_array.any?
+              j.child! do 
                 j.terms do
-                  j.set! Item::IndexFields::COLLECTION, @collections
+                  j.set! Item::IndexFields::COLLECTION, collections_array
                 end
               end
-            elsif @collection 
-              j.child! do 
+            elsif @collection
+              j.child! do
                 j.term do
                   j.set! Item::IndexFields::COLLECTION, @collection.repository_id
                 end

--- a/app/search/item_relation.rb
+++ b/app/search/item_relation.rb
@@ -30,7 +30,7 @@ class ItemRelation < AbstractRelation
   end
 
   def collections(ids)
-    @collections = ids
+    @collections = Array(ids).flatten.compact # Ensure that we have an array of IDs.
     self
   end
 


### PR DESCRIPTION
The following error(s) are being logged when some queries are passed in collection searches

```
Error
Class: IOError
Message: x_content_parse_exception: [terms] query does not support [sys_k_collection]
Path: /collections/:collection_id/items
```
Search Flow:

- User searches term (q="apple")
- Request is sent with params including the query and collection_ids or collection_id if searching a single collection
- The ItemsController parses the params and builds an ItemRelation object
- The ItemRelation objects builds an OpenSearch query, by setting `@collections or @collection` based on the params.

Potential error:
- If the ItemsController passes a string instead of an array to `.collections(params[:collection_ids]` or if both `@collections` and `@collection` are set, the code may build a terms query with a string value or duplicate filters:

```ruby
j.terms do
   j.set! Item::IndexFields::COLLECTION, @collections
```
Now OpenSearch expects an array for terms but receives a string or receives two filters for the same field. When it sees a `terms` clause for `sys_k_collection` with an invalid value it throws the parse exception.

Fix:
- `ItemRelation` sets collections to be always be an array of IDs 
- `build_query()` uses `collections_array` for terms clause

