### PR TITLE
Use representative image for (sub)collections if available

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -202,11 +202,13 @@ module ApplicationHelper
                                               region: 'square',
                                               size:   CARD_IMAGE_SIZE)
       else
-        case entity.class.to_s
-          when 'Collection'
-            img_url = image_url('fa-folder-open-o-600.png')
-          else
-            img_url = image_url('fa-cube-600.png')
+        # For collections, use representative image if available, otherwise show folder icon
+        if entity.class.to_s == 'Collection' && entity.representative_image.present?
+          img_url = ImageServer.file_image_v2_url(file: entity.representative_image, region: 'square', size: CARD_IMAGE_SIZE)
+        elsif entity.class.to_s == 'Collection'
+          img_url = image_url('fa-folder-open-o-600.png')
+        else
+          img_url = image_url('fa-cube-600.png')
         end
       end
       html << '<div class="dl-card">'


### PR DESCRIPTION
Addresses [issue 133](https://github.com/orgs/medusa-project/projects/2/views/3?pane=issue&itemId=111575530&issue=medusa-project%7Cdigital-library-issues%7C133) 

`sub-collections within a parent collection should display the correct representative image (if available), otherwise falls back to the generic folder icon`

_N.B.:_ I'm unable to test this locally since the images S3 bucket is not accessible in dev environment (as far as I know?). I will need to push this to demo first in order to test. 